### PR TITLE
v3.1 changes

### DIFF
--- a/Config/DefaultGameFuse.ini
+++ b/Config/DefaultGameFuse.ini
@@ -2,3 +2,5 @@
 +PropertyRedirects = (OldName="/Script/GameFuse.GFAPIResponse.ResponseString",NewName="/Script/GameFuse.GFAPIResponse.ResponseStr")
 +FunctionRedirects = (OldName="/Script/GameFuse.GameFuseManager.SetUpGame",NewName="/Script/GameFuse.GameFuseManager.BPSetUpGame")
 +FunctionRedirects = (OldName="/Script/GameFuse.GameFuseUser.FetchPurchaseStoreItems",NewName="/Script/GameFuse.GameFuseUser.FetchPurchasedStoreItems")
++FunctionRedirects=(OldName="/Script/GameFuse.GameFuseUser.BP_FetchPurchasedStoreItems",NewName="/Script/GameFuse.GameFuseUser.BP_FetchMyPurchasedStoreItems")
++FunctionRedirects=(OldName="/Script/GameFuse.GameFuseUser.BP_FetchAttributes",NewName="/Script/GameFuse.GameFuseUser.BP_FetchMyAttributes")

--- a/GameFuse.uplugin
+++ b/GameFuse.uplugin
@@ -1,7 +1,7 @@
 {
   "FileVersion": 3,
-  "Version": "0209002",
-  "VersionName": "2.9.2",
+  "Version": "0300000",
+  "VersionName": "3.0.0",
   "FriendlyName": "GameFuse",
   "Description": "GameFuse is a web service for game developers. Add authentication, user data, leaderboards, in-game-store and more, all without setting up servers or managing API calls.",
   "Category": "CodePlugins",
@@ -10,7 +10,7 @@
   "DocsURL": "https://gamefuse.co/pages/docs?language=cpp",
   "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/6214da75e30c4ba5a713596d735589d8",
   "SupportURL": "https://gamefuse.co/pages/faq",
-  "EngineVersion": "5.5",
+  "EngineVersion": "5.4",
   "CanContainContent": true,
   "Installed": false,
   "Modules": [
@@ -26,7 +26,7 @@
     },
     {
       "Name": "GameFuseTests",
-      "Type": "DeveloperTool",
+      "Type": "Editor",
       "LoadingPhase": "Default",
       "PlatformAllowList": [
         "Win64",

--- a/Source/GameFuse/Private/API/APIRequestHandler.cpp
+++ b/Source/GameFuse/Private/API/APIRequestHandler.cpp
@@ -77,7 +77,7 @@ FGuid UAPIRequestHandler::SendRequest(const FString& Endpoint, const FString& Ht
 	// Add Default Headers
 	AddCommonHeaders(HttpRequest);
 
-	//Capture request in the lambda to prevent collection before handle response is called.
+	// Capture request in the lambda to prevent collection before handle response is called.
 	HttpRequest->OnProcessRequestComplete().BindLambda([this, RequestId](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful) {
 		HandleResponse(Request, Response, bWasSuccessful, RequestId);
 	});
@@ -108,7 +108,7 @@ void UAPIRequestHandler::SetAuthHeader(const FString& AuthToken)
 
 void UAPIRequestHandler::HandleResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, const bool bWasSuccessful, const FGuid& RequestId)
 {
-	//error checking
+	// error checking
 	if (!ActiveRequests.Contains(RequestId)) {
 		UE_LOG(LogGameFuse, Log, TEXT("Got response without an active request"));
 	}
@@ -118,10 +118,8 @@ void UAPIRequestHandler::HandleResponse(FHttpRequestPtr Request, FHttpResponsePt
 		return;
 	}
 
-	if (!Response.IsValid())
-	{
-		if (ResponseDelegates.Contains(RequestId))
-		{
+	if (!Response.IsValid()) {
+		if (ResponseDelegates.Contains(RequestId)) {
 			const FGFApiCallback& Delegate = ResponseDelegates[RequestId];
 			FString ResponseContent = TEXT("Bad Response, Request is not valid");
 			Delegate.Broadcast(FGFAPIResponse(false, ResponseContent, RequestId, 404));
@@ -151,13 +149,13 @@ void UAPIRequestHandler::HandleResponse(FHttpRequestPtr Request, FHttpResponsePt
 			UE_LOG(LogTemp, Log, TEXT("Request %s succeeded"), *RequestId.ToString());
 			GameFuseUtilities::LogResponse(Response);
 		} else {
-			UE_LOG(LogTemp, Error, TEXT("Request %s failed"), *RequestId.ToString());
+			UE_LOG(LogTemp, Warning, TEXT("Request %s failed"), *RequestId.ToString());
 			GameFuseUtilities::LogRequest(Request);
 			GameFuseUtilities::LogResponse(Response);
 		}
 	} else {
 		// Handle failure case here
-		UE_LOG(LogTemp, Error, TEXT("Request %s failed"), *RequestId.ToString());
+		UE_LOG(LogTemp, Warning, TEXT("Request %s failed"), *RequestId.ToString());
 		GameFuseUtilities::LogRequest(Request);
 	}
 

--- a/Source/GameFuse/Private/API/CoreAPIHandler.cpp
+++ b/Source/GameFuse/Private/API/CoreAPIHandler.cpp
@@ -64,3 +64,11 @@ FGuid UCoreAPIHandler::FetchStoreItems(const int GameID, const FString& Token, c
 	return SendRequest(ApiEndpoint, TEXT("GET"), Callback);
 
 }
+
+FGuid UCoreAPIHandler::GetServerTime(const FGFApiCallback& Callback)
+{
+	const FString ApiEndpoint = TEXT("/util/get_server_time");
+
+	UE_LOG(LogGameFuse, Verbose, TEXT("Sending Static Request - Getting Server Time"));
+	return SendRequest(ApiEndpoint, TEXT("GET"), Callback);
+}

--- a/Source/GameFuse/Private/API/FriendsAPIHandler.cpp
+++ b/Source/GameFuse/Private/API/FriendsAPIHandler.cpp
@@ -70,13 +70,24 @@ FGuid UFriendsAPIHandler::GetFriendshipData(const FGFUserData& UserData, const F
 	return SendRequest("/friendships", "GET", Callback);
 }
 
-FGuid UFriendsAPIHandler::GetFriendsList(const FGFUserData& UserData, const FGFApiCallback& Callback)
+FGuid UFriendsAPIHandler::GetMyFriendsList(const FGFUserData& UserData, const FGFApiCallback& Callback)
 {
 	if (!VerifyUserData(UserData)) {
 		return FGuid();
 	}
 	SetAuthHeader(UserData.AuthenticationToken);
 	return SendRequest("/friends", "GET", Callback);
+}
+
+FGuid UFriendsAPIHandler::GetUserFriendsList(const int32 UserId, const FGFUserData& UserData, const FGFApiCallback& Callback)
+{
+	if (!VerifyUserData(UserData))
+	{
+		return FGuid();
+	}
+	SetAuthHeader(UserData.AuthenticationToken);
+	const FString ApiEndpoint = FString::Printf(TEXT("/friends?user_id=%d"), UserId);
+	return SendRequest(ApiEndpoint, "GET", Callback);
 }
 
 FGuid UFriendsAPIHandler::GetOutgoingFriendRequests(const FGFUserData& UserData, const FGFApiCallback& Callback)

--- a/Source/GameFuse/Private/API/GroupsAPIHandler.cpp
+++ b/Source/GameFuse/Private/API/GroupsAPIHandler.cpp
@@ -42,6 +42,20 @@ FGuid UGroupsAPIHandler::RequestToJoinGroup(int32 GroupId, const FGFUserData& Us
 	return SendRequest("/group_connections", "POST", Callback, JsonObject);
 }
 
+FGuid UGroupsAPIHandler::InviteGroupMember(int32 GroupId, int32 UserIdToInvite, const FGFUserData& UserData, const FGFApiCallback& Callback)
+{
+	if (!VerifyUserData(UserData)) {
+		return FGuid();
+	}
+	SetAuthHeader(UserData.AuthenticationToken);
+
+	TSharedPtr<FJsonObject> JsonObject = MakeShared<FJsonObject>();
+	JsonObject->SetNumberField("group_id", GroupId);
+	JsonObject->SetNumberField("user_id", UserIdToInvite);
+
+	return SendRequest("/group_connections", "POST", Callback, JsonObject);
+}
+
 FGuid UGroupsAPIHandler::FetchGroup(int32 GroupId, const FGFUserData& UserData, const FGFApiCallback& Callback)
 {
 	if (!VerifyUserData(UserData)) {

--- a/Source/GameFuse/Private/API/GroupsAPIHandler.cpp
+++ b/Source/GameFuse/Private/API/GroupsAPIHandler.cpp
@@ -139,7 +139,7 @@ FGuid UGroupsAPIHandler::RemoveAdmin(const int32 GroupId, const int32 UserId, co
 	return SendRequest(ApiEndpoint, "DELETE", Callback);
 }
 
-FGuid UGroupsAPIHandler::AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOnlyCreatorCanEdit, const FGFUserData& UserData, const FGFApiCallback& Callback)
+FGuid UGroupsAPIHandler::AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOthersCanEdit, const FGFUserData& UserData, const FGFApiCallback& Callback)
 {
 	if (!VerifyUserData(UserData)) {
 		return FGuid();
@@ -153,7 +153,7 @@ FGuid UGroupsAPIHandler::AddAttribute(const int32 GroupId, const FGFGroupAttribu
 	TSharedPtr<FJsonObject> AttributeObject = MakeShared<FJsonObject>();
 	AttributeObject->SetStringField(TEXT("key"), Attribute.Key);
 	AttributeObject->SetStringField(TEXT("value"), Attribute.Value);
-	AttributeObject->SetBoolField(TEXT("only_can_edit_by_creator"), bOnlyCreatorCanEdit);
+	AttributeObject->SetBoolField(TEXT("others_can_edit"), bOthersCanEdit);
 
 	// Add it to the array
 	AttributesArray.Add(MakeShared<FJsonValueObject>(AttributeObject));

--- a/Source/GameFuse/Private/API/RoundsAPIHandler.cpp
+++ b/Source/GameFuse/Private/API/RoundsAPIHandler.cpp
@@ -50,16 +50,34 @@ FGuid URoundsAPIHandler::UpdateGameRound(const int32 RoundId, const FGFUserData&
 	return SendRequest(ApiEndpoint, "PUT", Callback, JsonObject);
 }
 
-FGuid URoundsAPIHandler::FetchUserGameRounds(const FGFUserData& UserData, const FGFApiCallback& Callback)
+FGuid URoundsAPIHandler::FetchUserGameRounds(const int32 UserId, const FGFUserData& UserData, const FString& GameType,
+                                             const int32 Page, const int32 PerPage, const FGFApiCallback& Callback)
 {
-	if (!VerifyUserData(UserData)) {
+	if (!VerifyUserData(UserData))
+	{
 		return FGuid();
 	}
 	SetAuthHeader(UserData.AuthenticationToken);
 
-	FString Endpoint = FString::Printf(TEXT("/game_rounds?user_id=%d"), UserData.Id);
+	TArray<FString> QueryParams;
+	QueryParams.Add(FString::Printf(TEXT("user_id=%d"), UserId));
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Fetching game rounds for user ID: %d"), UserData.Id);
+	if (!GameType.IsEmpty())
+	{
+		QueryParams.Add(FString::Printf(TEXT("game_type=%s"), *GameType));
+	}
+	if (Page > 0)
+	{
+		QueryParams.Add(FString::Printf(TEXT("page=%d"), Page));
+	}
+	if (PerPage > 0)
+	{
+		QueryParams.Add(FString::Printf(TEXT("per_page=%d"), PerPage));
+	}
+
+	FString Endpoint = FString::Printf(TEXT("/game_rounds?%s"), *FString::Join(QueryParams, TEXT("&")));
+
+	UE_LOG(LogGameFuse, Verbose, TEXT("Fetching game rounds with endpoint: %s"), *Endpoint);
 	return SendRequest(Endpoint, "GET", Callback);
 }
 

--- a/Source/GameFuse/Private/API/UserAPIHandler.cpp
+++ b/Source/GameFuse/Private/API/UserAPIHandler.cpp
@@ -15,7 +15,7 @@ FGuid UUserAPIHandler::SignUp(const FString& Email, const FString& Password, con
 	Body->SetStringField("password", Password);
 	Body->SetStringField("password_confirmation", PasswordConfirmation);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Sending Static Request - Signing Up"));
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Sending Static Request - Signing Up"));
 	return SendRequest(ApiEndpoint, "POST", Callback, Body);
 }
 
@@ -27,9 +27,15 @@ FGuid UUserAPIHandler::SignIn(const FString& Email, const FString& Password, con
 	Body->SetStringField("email", Email);
 	Body->SetStringField("password", Password);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Sending Static Request - Signing In"));
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Sending Static Request - Signing In"));
 
 	return SendRequest(ApiEndpoint, "POST", Callback, Body);
+}
+
+FGuid UUserAPIHandler::FetchUser(int32 UserId, const FGFApiCallback& InternalCallback)
+{
+	const FString ApiEndpoint = FString::Printf(TEXT("/users/%d"), UserId);
+	return SendRequest(ApiEndpoint, "GET", InternalCallback);
 }
 
 FGuid UUserAPIHandler::AddCredits(const int32 Credits, const FGFUserData& UserData, const FGFApiCallback& Callback)
@@ -44,7 +50,7 @@ FGuid UUserAPIHandler::AddCredits(const int32 Credits, const FGFUserData& UserDa
 	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
 	JsonObject->SetNumberField("credits", Credits);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Adding Credits: %d"), Credits);
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Adding Credits: %d"), Credits);
 	return SendRequest(ApiEndpoint, "POST", Callback, JsonObject);
 }
 
@@ -61,7 +67,7 @@ FGuid UUserAPIHandler::SetCredits(const int SetCredits, const FGFUserData& UserD
 	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
 	JsonObject->SetNumberField("credits", SetCredits);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Setting Credits: %d"), SetCredits);
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Setting Credits: %d"), SetCredits);
 	return SendRequest(ApiEndpoint, "POST", Callback, JsonObject);
 }
 
@@ -77,7 +83,7 @@ FGuid UUserAPIHandler::AddScore(const int32 Score, const FGFUserData& UserData, 
 	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
 	JsonObject->SetNumberField("score", Score);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Adding Score: %d"), Score);
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Adding Score: %d"), Score);
 	return SendRequest(ApiEndpoint, "POST", Callback, JsonObject);
 }
 
@@ -93,7 +99,7 @@ FGuid UUserAPIHandler::SetScore(const int32 Score, const FGFUserData& UserData, 
 	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
 	JsonObject->SetNumberField("score", Score);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Setting Score: %d"), Score);
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Setting Score: %d"), Score);
 	return SendRequest(ApiEndpoint, "POST", Callback, JsonObject);
 }
 
@@ -110,7 +116,7 @@ FGuid UUserAPIHandler::SetAttribute(const FString& SetKey, const FString& SetVal
 	JsonObject->SetStringField("key", SetKey);
 	JsonObject->SetStringField("value", SetValue);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Setting Attribute: %s : %s"), *SetKey, *SetValue);
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Setting Attribute: %s : %s"), *SetKey, *SetValue);
 	return SendRequest(ApiEndpoint, "POST", Callback, JsonObject);
 }
 
@@ -137,7 +143,7 @@ FGuid UUserAPIHandler::SetAttributes(const TMap<FString, FString>& Attributes, c
 
 	JsonObject->SetArrayField("attributes", AttributesArray);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Setting %d attributes in batch"), Attributes.Num());
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Setting %d attributes in batch"), Attributes.Num());
 	return SendRequest(ApiEndpoint, "POST", Callback, JsonObject);
 }
 
@@ -150,7 +156,7 @@ FGuid UUserAPIHandler::RemoveAttribute(const FString& Key, const FGFUserData& Us
 	SetAuthHeader(UserData.AuthenticationToken);
 	const FString ApiEndpoint = FString::Printf(TEXT("/users/%d/remove_game_user_attributes?game_user_attribute_key=%s"), UserData.Id, *Key);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Removing Attribute: %s"), *Key);
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Removing Attribute: %s"), *Key);
 	return SendRequest(ApiEndpoint, "GET", Callback);
 }
 
@@ -166,7 +172,7 @@ FGuid UUserAPIHandler::PurchaseStoreItem(const int32 StoreItemId, const FGFUserD
 	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
 	JsonObject->SetNumberField("store_item_id", StoreItemId);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Purchasing Store Item: %d"), StoreItemId);
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Purchasing Store Item: %d"), StoreItemId);
 	return SendRequest(ApiEndpoint, "POST", Callback, JsonObject);
 }
 
@@ -182,7 +188,7 @@ FGuid UUserAPIHandler::RemoveStoreItem(const int32 StoreItemId, const FGFUserDat
 	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
 	JsonObject->SetNumberField("store_item_id", StoreItemId);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Removing Store Item: %d"), StoreItemId);
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Removing Store Item: %d"), StoreItemId);
 	return SendRequest(ApiEndpoint, "GET", Callback);
 }
 
@@ -209,7 +215,7 @@ FGuid UUserAPIHandler::AddLeaderboardEntry(const FGFLeaderboardEntry& Leaderboar
 	if (GameFuseUtilities::ConvertLeaderboardItemToJson(LeaderboardEntry, JsonObject)) {
 		const FString ApiEndpoint = FString::Printf(TEXT("/users/%d/add_leaderboard_entry"), UserData.Id);
 
-		UE_LOG(LogGameFuse, Verbose, TEXT("User Adding Leaderboard : %s : %d"), *LeaderboardEntry.LeaderboardName, LeaderboardEntry.Score);
+		// UE_LOG(LogGameFuse, Verbose, TEXT("User Adding Leaderboard : %s : %d"), *LeaderboardEntry.LeaderboardName, LeaderboardEntry.Score);
 		return SendRequest(ApiEndpoint, "POST", Callback, JsonObject);
 	}
 	return FGuid();
@@ -224,7 +230,7 @@ FGuid UUserAPIHandler::ClearLeaderboardEntry(const FString& LeaderboardName, con
 	SetAuthHeader(UserData.AuthenticationToken);
 	const FString ApiEndpoint = FString::Printf(TEXT("/users/%d/clear_my_leaderboard_entries?leaderboard_name=%s"), UserData.Id, *LeaderboardName);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("User Clearing Leaderboard : %s"), *LeaderboardName);
+	// UE_LOG(LogGameFuse, Verbose, TEXT("User Clearing Leaderboard : %s"), *LeaderboardName);
 	return SendRequest(ApiEndpoint, "POST", Callback);
 }
 
@@ -238,7 +244,7 @@ FGuid UUserAPIHandler::FetchLeaderboardEntries(const int32 Limit, bool bOnePerUs
 	const FString ApiEndpoint = FString::Printf(TEXT("/users/%d/leaderboard_entries?limit=%d&one_per_user=%s"),
 												UserData.Id, Limit, bOnePerUser ? TEXT("true") : TEXT("false"));
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("Fetching My Leaderboard : %d : %s"), Limit, bOnePerUser ? TEXT("true") : TEXT("false"));
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Fetching My Leaderboard : %d : %s"), Limit, bOnePerUser ? TEXT("true") : TEXT("false"));
 	return SendRequest(ApiEndpoint, "GET", Callback);
 }
 
@@ -254,7 +260,7 @@ FGuid UUserAPIHandler::FetchAttributes(const FGFUserData& UserData, const FGFApi
 
 	const FString ApiEndpoint = FString::Printf(TEXT("/users/%d/game_user_attributes"), UserData.Id);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("User Fetching Attributes"));
+	// UE_LOG(LogGameFuse, Verbose, TEXT("User Fetching Attributes"));
 
 	return SendRequest(ApiEndpoint, "GET", Callback);
 }
@@ -269,7 +275,7 @@ FGuid UUserAPIHandler::FetchPurchasedStoreItems(const FGFUserData& UserData, con
 
 	const FString ApiEndpoint = FString::Printf(TEXT("/users/%d/game_user_store_items"), UserData.Id);
 
-	UE_LOG(LogGameFuse, Verbose, TEXT("User Fetching Purchased Store Items"));
+	// UE_LOG(LogGameFuse, Verbose, TEXT("User Fetching Purchased Store Items"));
 
 	return SendRequest(ApiEndpoint, "GET", Callback);
 }

--- a/Source/GameFuse/Private/API/UserAPIHandler.cpp
+++ b/Source/GameFuse/Private/API/UserAPIHandler.cpp
@@ -154,10 +154,33 @@ FGuid UUserAPIHandler::RemoveAttribute(const FString& Key, const FGFUserData& Us
 	}
 
 	SetAuthHeader(UserData.AuthenticationToken);
-	const FString ApiEndpoint = FString::Printf(TEXT("/users/%d/remove_game_user_attributes?game_user_attribute_key=%s"), UserData.Id, *Key);
+	const FString ApiEndpoint = FString::Printf(TEXT("/users/%d/remove_game_user_attribute?game_user_attribute_key=%s"), UserData.Id, *Key);
 
 	// UE_LOG(LogGameFuse, Verbose, TEXT("Removing Attribute: %s"), *Key);
-	return SendRequest(ApiEndpoint, "GET", Callback);
+	return SendRequest(ApiEndpoint, "DELETE", Callback);
+}
+
+FGuid UUserAPIHandler::RemoveAttributes(const TArray<FString>& AttributeKeys, const FGFUserData& UserData, const FGFApiCallback& Callback)
+{
+	if (!VerifyUserData(UserData)) {
+		return FGuid();
+	}
+
+	SetAuthHeader(UserData.AuthenticationToken);
+	const FString ApiEndpoint = FString::Printf(TEXT("/users/%d/remove_game_user_attributes"), UserData.Id);
+
+	// Create JSON object for batch attributes
+	TSharedPtr<FJsonObject> JsonObject = MakeShareable(new FJsonObject);
+
+	TArray<TSharedPtr<FJsonValue>> KeysArray;
+	for (const FString& Key : AttributeKeys) {
+		KeysArray.Add(MakeShareable(new FJsonValueString(Key)));
+	}
+
+	JsonObject->SetArrayField("game_user_attribute_keys", KeysArray);
+
+	// UE_LOG(LogGameFuse, Verbose, TEXT("Setting %d attributes in batch"), Attributes.Num());
+	return SendRequest(ApiEndpoint, "DELETE", Callback, JsonObject);
 }
 
 FGuid UUserAPIHandler::PurchaseStoreItem(const int32 StoreItemId, const FGFUserData& UserData, const FGFApiCallback& Callback)

--- a/Source/GameFuse/Private/API/UserAPIHandler.cpp
+++ b/Source/GameFuse/Private/API/UserAPIHandler.cpp
@@ -228,7 +228,7 @@ FGuid UUserAPIHandler::ClearLeaderboardEntry(const FString& LeaderboardName, con
 	return SendRequest(ApiEndpoint, "POST", Callback);
 }
 
-FGuid UUserAPIHandler::FetchMyLeaderboardEntries(const int32 Limit, bool bOnePerUser, const FGFUserData& UserData, const FGFApiCallback& Callback)
+FGuid UUserAPIHandler::FetchLeaderboardEntries(const int32 Limit, bool bOnePerUser, const FGFUserData& UserData, const FGFApiCallback& Callback)
 {
 	if (!VerifyUserData(UserData)) {
 		return FGuid();

--- a/Source/GameFuse/Private/Library/GameFuseUtilities.cpp
+++ b/Source/GameFuse/Private/Library/GameFuseUtilities.cpp
@@ -1326,4 +1326,30 @@ bool GameFuseUtilities::ConvertJsonToFriendRequest(FGFFriendRequest& OutRequest,
 	return ConvertJsonToFriendRequest(OutRequest, JsonObject);
 }
 
+bool GameFuseUtilities::ConvertJsonToServerTime(FString& OutServerTime, const FString& JsonString)
+{
+	OutServerTime.Empty();
+
+	if (JsonString.IsEmpty()) {
+		UE_LOG(LogGameFuse, Error, TEXT("Empty JSON string for server time"));
+		return false;
+	}
+
+	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonString);
+	TSharedPtr<FJsonObject> JsonObject;
+
+	if (!FJsonSerializer::Deserialize(Reader, JsonObject) || !JsonObject.IsValid()) {
+		UE_LOG(LogGameFuse, Error, TEXT("Failed to parse JSON string for server time"));
+		return false;
+	}
+
+	if (!JsonObject->TryGetStringField(TEXT("server_time"), OutServerTime)) {
+		UE_LOG(LogGameFuse, Warning, TEXT("No server_time field found in JSON"));
+		return false;
+	}
+
+	UE_LOG(LogGameFuse, Log, TEXT("Parsed server time: %s"), *OutServerTime);
+	return true;
+}
+
 #pragma endregion

--- a/Source/GameFuse/Private/Library/GameFuseUtilities.cpp
+++ b/Source/GameFuse/Private/Library/GameFuseUtilities.cpp
@@ -1120,15 +1120,16 @@ bool GameFuseUtilities::ConvertJsonObjectToStringMap(const TSharedPtr<FJsonObjec
 
 
 	// if field is null, return success and skip
-	if (JsonObject->HasTypedField(FStringView(FieldKey), EJson::Null)) {
+	if (!JsonObject->HasField(FieldKey)) {
 		UE_LOG(LogGameFuse, Log, TEXT("ConvertJsonObjectToStringMap: %s field is null, skipping"), *FieldKey);
+
 		return true;
 	}
 
 	// if FieldKey is not empty, assume the object is a field in the map
 	// aka the json object looks like {"field_key": {"key1": "value1", "key2": "value2"}}
 	const TSharedPtr<FJsonObject>* SrcJsonObject = nullptr;
-	if (JsonObject->TryGetObjectField(FStringView(FieldKey), SrcJsonObject)) {
+	if (JsonObject->TryGetObjectField(FieldKey, SrcJsonObject)) {
 		if (!SrcJsonObject->IsValid()) {
 			UE_LOG(LogGameFuse, Warning, TEXT("ConvertJsonObjectToStringMap: Invalid object value for field: %s"), *FieldKey);
 			return false;

--- a/Source/GameFuse/Private/Library/GameFuseUtilities.cpp
+++ b/Source/GameFuse/Private/Library/GameFuseUtilities.cpp
@@ -781,6 +781,28 @@ bool GameFuseUtilities::ConvertJsonArrayToGroupAttributes(TArray<FGFGroupAttribu
 	return true;
 }
 
+
+bool GameFuseUtilities::ConvertJsonArrayToGroupConnections(TArray<FGFGroupConnection>& InConnections, const TArray<TSharedPtr<FJsonValue>>* JsonArray)
+{
+	if (!JsonArray) {
+		return false;
+	}
+
+	InConnections.Empty();
+	for (const auto& JsonValue : *JsonArray) {
+		if (JsonValue->Type != EJson::Object) {
+			continue;
+		}
+
+		FGFGroupConnection Connection;
+		if (ConvertJsonToGroupConnection(Connection, JsonValue->AsObject())) {
+			InConnections.Add(Connection);
+		}
+	}
+
+	return true;
+}
+
 bool GameFuseUtilities::ConvertJsonToGroupAttributeResponse(TArray<FGFGroupAttribute>& OutAttributes, const FString& JsonString)
 {
 	TSharedPtr<FJsonObject> JsonObject;
@@ -853,6 +875,16 @@ bool GameFuseUtilities::ConvertJsonToGroup(FGFGroup& InGroup, const TSharedPtr<F
 	const TArray<TSharedPtr<FJsonValue>>* AttributesArray;
 	if (JsonObject->TryGetArrayField(TEXT("attributes"), AttributesArray)) {
 		ConvertJsonArrayToGroupAttributes(InGroup.Attributes, AttributesArray);
+	}
+
+	const TArray<TSharedPtr<FJsonValue>>* JoinRequestsArray;
+	if (JsonObject->TryGetArrayField(TEXT("join_requests"), JoinRequestsArray)) {
+		ConvertJsonArrayToGroupConnections(InGroup.JoinRequests, JoinRequestsArray);
+	}
+
+	const TArray<TSharedPtr<FJsonValue>>* InvitesArray;
+	if (JsonObject->TryGetArrayField(TEXT("invites"), InvitesArray)) {
+		ConvertJsonArrayToGroupConnections(InGroup.Invites, InvitesArray);
 	}
 
 	return true;

--- a/Source/GameFuse/Private/Subsystems/GameFuseChat.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseChat.cpp
@@ -130,8 +130,8 @@ void UGameFuseChat::HandleChatListResponse(FGFAPIResponse Response)
 	}
 
 	// Parse the chats from the response
-	AllChats.Empty();
-	if (!GameFuseUtilities::ConvertJsonToChats(AllChats, Response.ResponseStr)) {
+	CachedChats.Empty();
+	if (!GameFuseUtilities::ConvertJsonToChats(CachedChats, Response.ResponseStr)) {
 		UE_LOG(LogGameFuse, Error, TEXT("Failed to parse chats from response"));
 		if (ChatListCallbacks.Contains(Response.RequestId)) {
 			ChatListCallbacks[Response.RequestId].ExecuteIfBound(TArray<FGFChat>());
@@ -143,7 +143,7 @@ void UGameFuseChat::HandleChatListResponse(FGFAPIResponse Response)
 	}
 
 	if (ChatListCallbacks.Contains(Response.RequestId)) {
-		ChatListCallbacks[Response.RequestId].ExecuteIfBound(AllChats);
+		ChatListCallbacks[Response.RequestId].ExecuteIfBound(CachedChats);
 		ChatListCallbacks.Remove(Response.RequestId);
 	}
 
@@ -247,10 +247,10 @@ FGuid UGameFuseChat::SendMessage(int32 ChatId, const FString& Text, FGFMessageCa
 	return RequestId;
 }
 
-void UGameFuseChat::BP_CreateChat(const TArray<FString>& ParticipantIds, const FString& InitialMessage, const FBP_GFApiCallback& Callback)
+void UGameFuseChat::BP_CreateChat(const TArray<FString>& Usernames, const FString& InitialMessage, const FBP_GFApiCallback& Callback)
 {
 	FGFChatCallback TypedCallback;
-	FGuid RequestId = CreateChat(ParticipantIds, InitialMessage, TypedCallback);
+	FGuid RequestId = CreateChat(Usernames, InitialMessage, TypedCallback);
 	StoreBlueprintCallback(RequestId, Callback);
 }
 

--- a/Source/GameFuse/Private/Subsystems/GameFuseChat.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseChat.cpp
@@ -51,7 +51,7 @@ FGuid UGameFuseChat::MarkMessageAsRead(int32 MessageId, FGFSuccessCallback Typed
 		HandleActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->MarkMessageAsRead(MessageId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->MarkMessageAsRead(MessageId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		ActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -71,7 +71,7 @@ FGuid UGameFuseChat::FetchAllChats(int32 Page, FGFChatListCallback TypedCallback
 		HandleChatListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchAllChats(GameFuseUser->GetLastFetchedUserData(), Page, InternalCallback);
+	FGuid RequestId = RequestHandler->FetchAllChats(GameFuseUser->GetCurrentUserData(), Page, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		ChatListCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -216,7 +216,7 @@ FGuid UGameFuseChat::CreateChat(const TArray<FString>& Usernames, const FString&
 	FGFMessage Message;
 	Message.Text = InitialMessage;
 
-	FGuid RequestId = RequestHandler->CreateChat(Usernames, Message, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->CreateChat(Usernames, Message, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		ChatCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -240,7 +240,7 @@ FGuid UGameFuseChat::SendMessage(int32 ChatId, const FString& Text, FGFMessageCa
 	FGFMessage Message;
 	Message.Text = Text;
 
-	FGuid RequestId = RequestHandler->SendMessage(ChatId, Message, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->SendMessage(ChatId, Message, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		MessageCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -288,7 +288,7 @@ FGuid UGameFuseChat::FetchMessages(int32 ChatId, int32 Page, FGFMessageListCallb
 		HandleMessageListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchMessages(ChatId, GameFuseUser->GetLastFetchedUserData(), Page, InternalCallback);
+	FGuid RequestId = RequestHandler->FetchMessages(ChatId, GameFuseUser->GetCurrentUserData(), Page, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		MessageListCallbacks.Add(RequestId, TypedCallback);
 	}

--- a/Source/GameFuse/Private/Subsystems/GameFuseChat.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseChat.cpp
@@ -51,7 +51,7 @@ FGuid UGameFuseChat::MarkMessageAsRead(int32 MessageId, FGFSuccessCallback Typed
 		HandleActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->MarkMessageAsRead(MessageId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->MarkMessageAsRead(MessageId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		ActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -71,7 +71,7 @@ FGuid UGameFuseChat::FetchAllChats(int32 Page, FGFChatListCallback TypedCallback
 		HandleChatListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchAllChats(GameFuseUser->GetUserData(), Page, InternalCallback);
+	FGuid RequestId = RequestHandler->FetchAllChats(GameFuseUser->GetLastFetchedUserData(), Page, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		ChatListCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -216,7 +216,7 @@ FGuid UGameFuseChat::CreateChat(const TArray<FString>& Usernames, const FString&
 	FGFMessage Message;
 	Message.Text = InitialMessage;
 
-	FGuid RequestId = RequestHandler->CreateChat(Usernames, Message, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->CreateChat(Usernames, Message, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		ChatCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -240,7 +240,7 @@ FGuid UGameFuseChat::SendMessage(int32 ChatId, const FString& Text, FGFMessageCa
 	FGFMessage Message;
 	Message.Text = Text;
 
-	FGuid RequestId = RequestHandler->SendMessage(ChatId, Message, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->SendMessage(ChatId, Message, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		MessageCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -288,7 +288,7 @@ FGuid UGameFuseChat::FetchMessages(int32 ChatId, int32 Page, FGFMessageListCallb
 		HandleMessageListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchMessages(ChatId, GameFuseUser->GetUserData(), Page, InternalCallback);
+	FGuid RequestId = RequestHandler->FetchMessages(ChatId, GameFuseUser->GetLastFetchedUserData(), Page, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		MessageListCallbacks.Add(RequestId, TypedCallback);
 	}

--- a/Source/GameFuse/Private/Subsystems/GameFuseFriends.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseFriends.cpp
@@ -45,7 +45,7 @@ FGuid UGameFuseFriends::SendFriendRequest(const FString& Username, FGFFriendRequ
 		HandleFriendRequestResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->SendFriendRequest(Username, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->SendFriendRequest(Username, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendRequestCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -65,7 +65,7 @@ FGuid UGameFuseFriends::AcceptFriendRequest(const int32 FriendshipId, FGFFriendA
 		HandleFriendActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RespondToFriendRequest(FriendshipId, EGFInviteRequestStatus::Accepted, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RespondToFriendRequest(FriendshipId, EGFInviteRequestStatus::Accepted, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -85,7 +85,7 @@ FGuid UGameFuseFriends::DeclineFriendRequest(const int32 FriendshipId, FGFFriend
 		HandleFriendActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RespondToFriendRequest(FriendshipId, EGFInviteRequestStatus::Declined, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RespondToFriendRequest(FriendshipId, EGFInviteRequestStatus::Declined, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -105,7 +105,7 @@ FGuid UGameFuseFriends::CancelFriendRequest(const int32 FriendshipId, FGFFriendA
 		HandleFriendActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->CancelFriendRequest(FriendshipId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->CancelFriendRequest(FriendshipId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -125,7 +125,7 @@ FGuid UGameFuseFriends::UnfriendPlayer(const int32 UserId, FGFFriendActionCallba
 		HandleFriendActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->UnfriendPlayer(UserId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->UnfriendPlayer(UserId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -145,7 +145,7 @@ FGuid UGameFuseFriends::FetchFriendshipData(FGFFriendsCallback TypedCallback)
 		HandleFriendshipDataResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->GetFriendshipData(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetFriendshipData(GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendsCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -165,7 +165,7 @@ FGuid UGameFuseFriends::FetchMyFriendsList(FGFFriendsCallback TypedCallback)
 		HandleFriendsListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->GetMyFriendsList(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetMyFriendsList(GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendsCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -187,7 +187,7 @@ FGuid UGameFuseFriends::FetchUserFriendsList(const int32 UserId, FGFFriendsCallb
 		HandleUserFriendsListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->GetUserFriendsList(UserId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetUserFriendsList(UserId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound())
 	{
 		FriendsCallbacks.Add(RequestId, TypedCallback);
@@ -208,7 +208,7 @@ FGuid UGameFuseFriends::FetchOutgoingFriendRequests(FGFFriendRequestsCallback Ty
 		HandleOutgoingRequestsResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->GetOutgoingFriendRequests(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetOutgoingFriendRequests(GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendRequestsCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -227,7 +227,7 @@ FGuid UGameFuseFriends::FetchIncomingFriendRequests(FGFFriendRequestsCallback Ty
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
 		HandleIncomingRequestsResponse(Response);
 	});
-	FGuid RequestId = RequestHandler->GetIncomingFriendRequests(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetIncomingFriendRequests(GameFuseUser->GetCurrentUserData(), InternalCallback);
 
 	if (TypedCallback.IsBound()) {
 		FriendRequestsCallbacks.Add(RequestId, TypedCallback);

--- a/Source/GameFuse/Private/Subsystems/GameFuseFriends.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseFriends.cpp
@@ -152,7 +152,7 @@ FGuid UGameFuseFriends::FetchFriendshipData(FGFFriendsCallback TypedCallback)
 	return RequestId;
 }
 
-FGuid UGameFuseFriends::FetchFriendsList(FGFFriendsCallback TypedCallback)
+FGuid UGameFuseFriends::FetchMyFriendsList(FGFFriendsCallback TypedCallback)
 {
 	UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser>();
 	if (!GameFuseUser || !GameFuseUser->IsSignedIn()) {
@@ -165,8 +165,31 @@ FGuid UGameFuseFriends::FetchFriendsList(FGFFriendsCallback TypedCallback)
 		HandleFriendsListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->GetFriendsList(GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetMyFriendsList(GameFuseUser->GetUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
+		FriendsCallbacks.Add(RequestId, TypedCallback);
+	}
+	return RequestId;
+}
+
+FGuid UGameFuseFriends::FetchUserFriendsList(const int32 UserId, FGFFriendsCallback TypedCallback)
+{
+	UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser>();
+	if (!GameFuseUser || !GameFuseUser->IsSignedIn())
+	{
+		UE_LOG(LogGameFuse, Error, TEXT("User must be signed in to fetch another user's friends list"));
+		return FGuid();
+	}
+
+	FGFApiCallback InternalCallback;
+	InternalCallback.AddLambda([this](const FGFAPIResponse& Response)
+	{
+		HandleUserFriendsListResponse(Response);
+	});
+
+	FGuid RequestId = RequestHandler->GetUserFriendsList(UserId, GameFuseUser->GetUserData(), InternalCallback);
+	if (TypedCallback.IsBound())
+	{
 		FriendsCallbacks.Add(RequestId, TypedCallback);
 	}
 	return RequestId;
@@ -404,6 +427,42 @@ void UGameFuseFriends::HandleFriendActionResponse(FGFAPIResponse Response)
 	ExecuteBlueprintCallback(Response);
 }
 
+void UGameFuseFriends::HandleUserFriendsListResponse(FGFAPIResponse Response)
+{
+	TArray<FGFUserData> UserFriendsList;
+	if (!Response.bSuccess)
+	{
+		UE_LOG(LogGameFuse, Error, TEXT("Failed to handle user friends list response: %s"), *Response.ResponseStr);
+		if (FriendsCallbacks.Contains(Response.RequestId))
+		{
+			FriendsCallbacks[Response.RequestId].ExecuteIfBound(UserFriendsList);
+			FriendsCallbacks.Remove(Response.RequestId);
+		}
+		ExecuteBlueprintCallback(Response);
+		return;
+	}
+
+	if (!GameFuseUtilities::ConvertJsonToFriendsList(UserFriendsList, Response.ResponseStr))
+	{
+		UE_LOG(LogGameFuse, Error, TEXT("Failed to parse user friends list"));
+		if (FriendsCallbacks.Contains(Response.RequestId))
+		{
+			FriendsCallbacks[Response.RequestId].ExecuteIfBound(TArray<FGFUserData>());
+			FriendsCallbacks.Remove(Response.RequestId);
+		}
+		ExecuteBlueprintCallback(Response);
+		return;
+	}
+
+	if (FriendsCallbacks.Contains(Response.RequestId))
+	{
+		FriendsCallbacks[Response.RequestId].ExecuteIfBound(UserFriendsList);
+		FriendsCallbacks.Remove(Response.RequestId);
+	}
+
+	ExecuteBlueprintCallback(Response);
+}
+
 void UGameFuseFriends::BP_SendFriendRequest(const FString& Username, const FBP_GFApiCallback& Callback)
 {
 	FGFFriendRequestCallback TypedCallback;
@@ -446,10 +505,17 @@ void UGameFuseFriends::BP_FetchFriendshipData(const FBP_GFApiCallback& Callback)
 	StoreBlueprintCallback(RequestId, Callback);
 }
 
-void UGameFuseFriends::BP_FetchFriendsList(const FBP_GFApiCallback& Callback)
+void UGameFuseFriends::BP_FetchMyFriendsList(const FBP_GFApiCallback& Callback)
 {
 	FGFFriendsCallback TypedCallback;
-	FGuid RequestId = FetchFriendsList(TypedCallback);
+	FGuid RequestId = FetchMyFriendsList(TypedCallback);
+	StoreBlueprintCallback(RequestId, Callback);
+}
+
+void UGameFuseFriends::BP_FetchUserFriendsList(const int32 UserId, const FBP_GFApiCallback& Callback)
+{
+	FGFFriendsCallback TypedCallback;
+	FGuid RequestId = FetchUserFriendsList(UserId, TypedCallback);
 	StoreBlueprintCallback(RequestId, Callback);
 }
 

--- a/Source/GameFuse/Private/Subsystems/GameFuseFriends.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseFriends.cpp
@@ -45,7 +45,7 @@ FGuid UGameFuseFriends::SendFriendRequest(const FString& Username, FGFFriendRequ
 		HandleFriendRequestResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->SendFriendRequest(Username, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->SendFriendRequest(Username, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendRequestCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -65,7 +65,7 @@ FGuid UGameFuseFriends::AcceptFriendRequest(const int32 FriendshipId, FGFFriendA
 		HandleFriendActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RespondToFriendRequest(FriendshipId, EGFInviteRequestStatus::Accepted, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RespondToFriendRequest(FriendshipId, EGFInviteRequestStatus::Accepted, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -85,7 +85,7 @@ FGuid UGameFuseFriends::DeclineFriendRequest(const int32 FriendshipId, FGFFriend
 		HandleFriendActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RespondToFriendRequest(FriendshipId, EGFInviteRequestStatus::Declined, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RespondToFriendRequest(FriendshipId, EGFInviteRequestStatus::Declined, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -105,7 +105,7 @@ FGuid UGameFuseFriends::CancelFriendRequest(const int32 FriendshipId, FGFFriendA
 		HandleFriendActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->CancelFriendRequest(FriendshipId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->CancelFriendRequest(FriendshipId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -125,7 +125,7 @@ FGuid UGameFuseFriends::UnfriendPlayer(const int32 UserId, FGFFriendActionCallba
 		HandleFriendActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->UnfriendPlayer(UserId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->UnfriendPlayer(UserId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -145,7 +145,7 @@ FGuid UGameFuseFriends::FetchFriendshipData(FGFFriendsCallback TypedCallback)
 		HandleFriendshipDataResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->GetFriendshipData(GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetFriendshipData(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendsCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -165,7 +165,7 @@ FGuid UGameFuseFriends::FetchMyFriendsList(FGFFriendsCallback TypedCallback)
 		HandleFriendsListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->GetMyFriendsList(GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetMyFriendsList(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendsCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -187,7 +187,7 @@ FGuid UGameFuseFriends::FetchUserFriendsList(const int32 UserId, FGFFriendsCallb
 		HandleUserFriendsListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->GetUserFriendsList(UserId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetUserFriendsList(UserId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound())
 	{
 		FriendsCallbacks.Add(RequestId, TypedCallback);
@@ -208,7 +208,7 @@ FGuid UGameFuseFriends::FetchOutgoingFriendRequests(FGFFriendRequestsCallback Ty
 		HandleOutgoingRequestsResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->GetOutgoingFriendRequests(GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetOutgoingFriendRequests(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		FriendRequestsCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -227,7 +227,7 @@ FGuid UGameFuseFriends::FetchIncomingFriendRequests(FGFFriendRequestsCallback Ty
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
 		HandleIncomingRequestsResponse(Response);
 	});
-	FGuid RequestId = RequestHandler->GetIncomingFriendRequests(GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->GetIncomingFriendRequests(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 
 	if (TypedCallback.IsBound()) {
 		FriendRequestsCallbacks.Add(RequestId, TypedCallback);

--- a/Source/GameFuse/Private/Subsystems/GameFuseGroups.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseGroups.cpp
@@ -47,7 +47,7 @@ FGuid UGameFuseGroups::CreateGroup(const FGFGroup& Group, FGFGroupCallback Typed
 		HandleGroupResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->CreateGroup(Group, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->CreateGroup(Group, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -67,7 +67,7 @@ FGuid UGameFuseGroups::FetchGroup(const int32 GroupId, FGFGroupCallback TypedCal
 		HandleGroupResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->FetchGroup(GroupId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -87,7 +87,7 @@ FGuid UGameFuseGroups::FetchAllGroups(FGFGroupListCallback TypedCallback)
 		HandleGroupListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchAllGroups(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->FetchAllGroups(GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupListCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -107,7 +107,27 @@ FGuid UGameFuseGroups::RequestToJoinGroup(int32 GroupId, FGFGroupConnectionCallb
 		HandleGroupConnectionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RequestToJoinGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RequestToJoinGroup(GroupId, GameFuseUser->GetCurrentUserData(), InternalCallback);
+	if (TypedCallback.IsBound()) {
+		GroupConnectionCallbacks.Add(RequestId, TypedCallback);
+	}
+	return RequestId;
+}
+
+FGuid UGameFuseGroups::InviteGroupMember(int32 GroupId, int32 UserIdToInvite, FGFGroupConnectionCallback TypedCallback)
+{
+	UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser>();
+	if (!GameFuseUser || !GameFuseUser->IsSignedIn()) {
+		UE_LOG(LogGameFuse, Error, TEXT("User must be signed in to invite a user to a group"));
+		return FGuid();
+	}
+
+	FGFApiCallback InternalCallback;
+	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
+		HandleGroupConnectionResponse(Response);
+	});
+
+	FGuid RequestId = RequestHandler->InviteGroupMember(GroupId, UserIdToInvite, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupConnectionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -127,7 +147,7 @@ FGuid UGameFuseGroups::DeleteGroup(const int32 GroupId, FGFGroupActionCallback T
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->DeleteGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->DeleteGroup(GroupId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -147,7 +167,7 @@ FGuid UGameFuseGroups::JoinGroup(const int32 GroupId, FGFGroupActionCallback Typ
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->JoinGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->JoinGroup(GroupId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -167,7 +187,7 @@ FGuid UGameFuseGroups::LeaveGroup(const int32 GroupId, FGFGroupActionCallback Ty
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->LeaveGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->LeaveGroup(GroupId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -187,7 +207,7 @@ FGuid UGameFuseGroups::FetchMyGroups(FGFGroupListCallback TypedCallback)
 		HandleGroupListResponse(Response, true);
 	});
 
-	FGuid RequestId = RequestHandler->FetchUserGroups(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->FetchUserGroups(GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupListCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -207,7 +227,7 @@ FGuid UGameFuseGroups::SearchGroups(const FString& Query, FGFGroupListCallback T
 		HandleGroupListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->SearchGroups(Query, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->SearchGroups(Query, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupListCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -227,7 +247,7 @@ FGuid UGameFuseGroups::AddAdmin(const int32 GroupId, const int32 UserId, FGFGrou
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->AddAdmin(GroupId, UserId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->AddAdmin(GroupId, UserId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -247,7 +267,7 @@ FGuid UGameFuseGroups::RemoveAdmin(const int32 GroupId, const int32 UserId, FGFG
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RemoveAdmin(GroupId, UserId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RemoveAdmin(GroupId, UserId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -267,7 +287,7 @@ FGuid UGameFuseGroups::AddAttribute(const int32 GroupId, const FGFGroupAttribute
 		HandleGroupAttributeResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->AddAttribute(GroupId, Attribute, bOthersCanEdit, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->AddAttribute(GroupId, Attribute, bOthersCanEdit, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupAttributeCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -287,7 +307,7 @@ FGuid UGameFuseGroups::UpdateGroupAttribute(const int32 GroupId, const FGFGroupA
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->UpdateGroupAttribute(GroupId, Attribute, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->UpdateGroupAttribute(GroupId, Attribute, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -332,7 +352,7 @@ FGuid UGameFuseGroups::RespondToGroupJoinRequest(const int32 ConnectionId, const
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RespondToGroupJoinRequest(ConnectionId, UserId, Status, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RespondToGroupJoinRequest(ConnectionId, UserId, Status, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -352,7 +372,7 @@ FGuid UGameFuseGroups::FetchGroupAttributes(const int32 GroupId, FGFGroupAttribu
 		HandleGroupAttributeResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchGroupAttributes(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->FetchGroupAttributes(GroupId, GameFuseUser->GetCurrentUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupAttributeCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -441,7 +461,7 @@ void UGameFuseGroups::HandleGroupListResponse(const FGFAPIResponse& Response, bo
 void UGameFuseGroups::HandleGroupConnectionResponse(const FGFAPIResponse& Response)
 {
 	if (!Response.bSuccess) {
-		UE_LOG(LogGameFuse, Error, TEXT("Failed to handle group connection response: %s"), *Response.ResponseStr);
+		UE_LOG(LogGameFuse, Warning, TEXT("Failed to handle group connection response: %s"), *Response.ResponseStr);
 		if (GroupConnectionCallbacks.Contains(Response.RequestId)) {
 			GroupConnectionCallbacks[Response.RequestId].ExecuteIfBound(FGFGroupConnection());
 			GroupConnectionCallbacks.Remove(Response.RequestId);
@@ -577,6 +597,13 @@ void UGameFuseGroups::BP_RequestToJoinGroup(int32 GroupId, const FBP_GFApiCallba
 {
 	FGFGroupConnectionCallback TypedCallback;
 	FGuid RequestId = RequestToJoinGroup(GroupId, TypedCallback);
+	StoreBlueprintCallback(RequestId, Callback);
+}
+
+void UGameFuseGroups::BP_InviteGroupMember(int32 GroupId, int32 UserIdToInvite, const FBP_GFApiCallback& Callback)
+{
+	FGFGroupConnectionCallback TypedCallback;
+	FGuid RequestId = InviteGroupMember(GroupId, UserIdToInvite, TypedCallback);
 	StoreBlueprintCallback(RequestId, Callback);
 }
 

--- a/Source/GameFuse/Private/Subsystems/GameFuseGroups.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseGroups.cpp
@@ -47,7 +47,7 @@ FGuid UGameFuseGroups::CreateGroup(const FGFGroup& Group, FGFGroupCallback Typed
 		HandleGroupResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->CreateGroup(Group, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->CreateGroup(Group, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -67,7 +67,7 @@ FGuid UGameFuseGroups::FetchGroup(const int32 GroupId, FGFGroupCallback TypedCal
 		HandleGroupResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchGroup(GroupId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->FetchGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -87,7 +87,7 @@ FGuid UGameFuseGroups::FetchAllGroups(FGFGroupListCallback TypedCallback)
 		HandleGroupListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchAllGroups(GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->FetchAllGroups(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupListCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -107,7 +107,7 @@ FGuid UGameFuseGroups::RequestToJoinGroup(int32 GroupId, FGFGroupConnectionCallb
 		HandleGroupConnectionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RequestToJoinGroup(GroupId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RequestToJoinGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupConnectionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -127,7 +127,7 @@ FGuid UGameFuseGroups::DeleteGroup(const int32 GroupId, FGFGroupActionCallback T
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->DeleteGroup(GroupId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->DeleteGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -147,7 +147,7 @@ FGuid UGameFuseGroups::JoinGroup(const int32 GroupId, FGFGroupActionCallback Typ
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->JoinGroup(GroupId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->JoinGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -167,7 +167,7 @@ FGuid UGameFuseGroups::LeaveGroup(const int32 GroupId, FGFGroupActionCallback Ty
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->LeaveGroup(GroupId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->LeaveGroup(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -187,7 +187,7 @@ FGuid UGameFuseGroups::FetchUserGroups(FGFGroupListCallback TypedCallback)
 		HandleGroupListResponse(Response, true);
 	});
 
-	FGuid RequestId = RequestHandler->FetchUserGroups(GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->FetchUserGroups(GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupListCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -207,7 +207,7 @@ FGuid UGameFuseGroups::SearchGroups(const FString& Query, FGFGroupListCallback T
 		HandleGroupListResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->SearchGroups(Query, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->SearchGroups(Query, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupListCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -227,7 +227,7 @@ FGuid UGameFuseGroups::AddAdmin(const int32 GroupId, const int32 UserId, FGFGrou
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->AddAdmin(GroupId, UserId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->AddAdmin(GroupId, UserId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -247,7 +247,7 @@ FGuid UGameFuseGroups::RemoveAdmin(const int32 GroupId, const int32 UserId, FGFG
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RemoveAdmin(GroupId, UserId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RemoveAdmin(GroupId, UserId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -267,7 +267,7 @@ FGuid UGameFuseGroups::AddAttribute(const int32 GroupId, const FGFGroupAttribute
 		HandleGroupAttributeResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->AddAttribute(GroupId, Attribute, bOthersCanEdit, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->AddAttribute(GroupId, Attribute, bOthersCanEdit, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupAttributeCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -287,7 +287,7 @@ FGuid UGameFuseGroups::UpdateGroupAttribute(const int32 GroupId, const FGFGroupA
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->UpdateGroupAttribute(GroupId, Attribute, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->UpdateGroupAttribute(GroupId, Attribute, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -332,7 +332,7 @@ FGuid UGameFuseGroups::RespondToGroupJoinRequest(const int32 ConnectionId, const
 		HandleGroupActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RespondToGroupJoinRequest(ConnectionId, UserId, Status, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->RespondToGroupJoinRequest(ConnectionId, UserId, Status, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupActionCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -352,7 +352,7 @@ FGuid UGameFuseGroups::FetchGroupAttributes(const int32 GroupId, FGFGroupAttribu
 		HandleGroupAttributeResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchGroupAttributes(GroupId, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->FetchGroupAttributes(GroupId, GameFuseUser->GetLastFetchedUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupAttributeCallbacks.Add(RequestId, TypedCallback);
 	}

--- a/Source/GameFuse/Private/Subsystems/GameFuseGroups.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseGroups.cpp
@@ -174,7 +174,7 @@ FGuid UGameFuseGroups::LeaveGroup(const int32 GroupId, FGFGroupActionCallback Ty
 	return RequestId;
 }
 
-FGuid UGameFuseGroups::FetchUserGroups(FGFGroupListCallback TypedCallback)
+FGuid UGameFuseGroups::FetchMyGroups(FGFGroupListCallback TypedCallback)
 {
 	UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser>();
 	if (!GameFuseUser || !GameFuseUser->IsSignedIn()) {
@@ -385,8 +385,8 @@ void UGameFuseGroups::HandleGroupResponse(const FGFAPIResponse& Response)
 	}
 
 	// Update cached data
-	UserGroups.AddUnique(Group);
-	AllGroups.AddUnique(Group);
+	MyGroups.AddUnique(Group);
+	FetchedGroups.AddUnique(Group);
 
 	if (GroupCallbacks.Contains(Response.RequestId)) {
 		GroupCallbacks[Response.RequestId].ExecuteIfBound(Group);
@@ -424,9 +424,9 @@ void UGameFuseGroups::HandleGroupListResponse(const FGFAPIResponse& Response, bo
 
 	// Update cached data
 	if (bIsUserGroups) {
-		UserGroups = Groups;
+		MyGroups = Groups;
 	} else {
-		AllGroups = Groups;
+		FetchedGroups = Groups;
 	}
 
 	if (GroupListCallbacks.Contains(Response.RequestId)) {
@@ -601,10 +601,10 @@ void UGameFuseGroups::BP_LeaveGroup(const int32 GroupId, const FBP_GFApiCallback
 	StoreBlueprintCallback(RequestId, Callback);
 }
 
-void UGameFuseGroups::BP_FetchUserGroups(const FBP_GFApiCallback& Callback)
+void UGameFuseGroups::BP_FetchMyGroups(const FBP_GFApiCallback& Callback)
 {
 	FGFGroupListCallback TypedCallback;
-	FGuid RequestId = FetchUserGroups(TypedCallback);
+	FGuid RequestId = FetchMyGroups(TypedCallback);
 	StoreBlueprintCallback(RequestId, Callback);
 }
 
@@ -677,7 +677,7 @@ void UGameFuseGroups::BP_DeclineGroupJoinRequest(const int32 ConnectionId, const
 bool UGameFuseGroups::GetGroupById(const int32 GroupId, FGFGroup& OutGroup) const
 {
 	// First check in UserGroups
-	for (const FGFGroup& Group : UserGroups) {
+	for (const FGFGroup& Group : MyGroups) {
 		if (Group.Id == GroupId) {
 			OutGroup = Group;
 			return true;
@@ -685,7 +685,7 @@ bool UGameFuseGroups::GetGroupById(const int32 GroupId, FGFGroup& OutGroup) cons
 	}
 
 	// If not found in UserGroups, check in AllGroups
-	for (const FGFGroup& Group : AllGroups) {
+	for (const FGFGroup& Group : FetchedGroups) {
 		if (Group.Id == GroupId) {
 			OutGroup = Group;
 			return true;

--- a/Source/GameFuse/Private/Subsystems/GameFuseGroups.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseGroups.cpp
@@ -254,7 +254,7 @@ FGuid UGameFuseGroups::RemoveAdmin(const int32 GroupId, const int32 UserId, FGFG
 	return RequestId;
 }
 
-FGuid UGameFuseGroups::AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOnlyCreatorCanEdit, FGFGroupAttributeCallback TypedCallback)
+FGuid UGameFuseGroups::AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOthersCanEdit, FGFGroupAttributeCallback TypedCallback)
 {
 	UGameFuseUser* GameFuseUser = GetGameInstance()->GetSubsystem<UGameFuseUser>();
 	if (!GameFuseUser || !GameFuseUser->IsSignedIn()) {
@@ -267,7 +267,7 @@ FGuid UGameFuseGroups::AddAttribute(const int32 GroupId, const FGFGroupAttribute
 		HandleGroupAttributeResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->AddAttribute(GroupId, Attribute, bOnlyCreatorCanEdit, GameFuseUser->GetUserData(), InternalCallback);
+	FGuid RequestId = RequestHandler->AddAttribute(GroupId, Attribute, bOthersCanEdit, GameFuseUser->GetUserData(), InternalCallback);
 	if (TypedCallback.IsBound()) {
 		GroupAttributeCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -629,10 +629,10 @@ void UGameFuseGroups::BP_RemoveAdmin(const int32 GroupId, const int32 UserId, co
 	StoreBlueprintCallback(RequestId, Callback);
 }
 
-void UGameFuseGroups::BP_AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOnlyCreatorCanEdit, const FBP_GFApiCallback& Callback)
+void UGameFuseGroups::BP_AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOthersCanEdit, const FBP_GFApiCallback& Callback)
 {
 	FGFGroupAttributeCallback TypedCallback;
-	FGuid RequestId = AddAttribute(GroupId, Attribute, bOnlyCreatorCanEdit, TypedCallback);
+	FGuid RequestId = AddAttribute(GroupId, Attribute, bOthersCanEdit, TypedCallback);
 	StoreBlueprintCallback(RequestId, Callback);
 }
 

--- a/Source/GameFuse/Private/Subsystems/GameFuseManager.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseManager.cpp
@@ -142,11 +142,11 @@ void UGameFuseManager::BP_FetchLeaderboardEntries(const int Limit = 20, bool bOn
 	StoreBlueprintCallback(RequestId, Callback);
 }
 
-void UGameFuseManager::BP_GetServerTime(const FBP_GFApiCallback& Callback = FBP_GFApiCallback())
+void UGameFuseManager::BP_FetchServerTime(const FBP_GFApiCallback& Callback = FBP_GFApiCallback())
 {
 	FGFApiCallback InternalCallback;
 
-	FGuid RequestId = GetServerTime(InternalCallback);
+	FGuid RequestId = FetchServerTime(InternalCallback);
 	StoreBlueprintCallback(RequestId, Callback);
 }
 
@@ -204,7 +204,7 @@ FGuid UGameFuseManager::FetchLeaderboardEntries(const int Limit, bool bOnePerUse
 	if (!SetupCheck()) {
 		return FGuid();
 	}
-	const FGFUserData& UserData = GetGameInstance()->GetSubsystem<UGameFuseUser>()->GetUserData();
+	const FGFUserData& UserData = GetGameInstance()->GetSubsystem<UGameFuseUser>()->GetLastFetchedUserData();
 
 	Callback.AddUObject(this, &UGameFuseManager::HandleLeaderboardEntriesResponse);
 	return RequestHandler->FetchLeaderboardEntries(Limit, bOnePerUser, LeaderboardName, GameData.Id, UserData.AuthenticationToken, Callback);
@@ -220,7 +220,7 @@ FGuid UGameFuseManager::FetchStoreItems(FGFApiCallback Callback)
 	return RequestHandler->FetchStoreItems(GameData.Id, GameData.Token, Callback);
 }
 
-FGuid UGameFuseManager::GetServerTime(FGFApiCallback Callback)
+FGuid UGameFuseManager::FetchServerTime(FGFApiCallback Callback)
 {
 	// Note: GetServerTime doesn't require setup check as it's a utility endpoint
 	Callback.AddUObject(this, &UGameFuseManager::HandleGetServerTimeResponse);

--- a/Source/GameFuse/Private/Subsystems/GameFuseManager.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseManager.cpp
@@ -142,6 +142,14 @@ void UGameFuseManager::BP_FetchLeaderboardEntries(const int Limit = 20, bool bOn
 	StoreBlueprintCallback(RequestId, Callback);
 }
 
+void UGameFuseManager::BP_GetServerTime(const FBP_GFApiCallback& Callback = FBP_GFApiCallback())
+{
+	FGFApiCallback InternalCallback;
+
+	FGuid RequestId = GetServerTime(InternalCallback);
+	StoreBlueprintCallback(RequestId, Callback);
+}
+
 #pragma endregion
 
 #pragma region CPP Implementations
@@ -210,6 +218,13 @@ FGuid UGameFuseManager::FetchStoreItems(FGFApiCallback Callback)
 
 	Callback.AddUObject(this, &UGameFuseManager::HandleStoreItemsResponse);
 	return RequestHandler->FetchStoreItems(GameData.Id, GameData.Token, Callback);
+}
+
+FGuid UGameFuseManager::GetServerTime(FGFApiCallback Callback)
+{
+	// Note: GetServerTime doesn't require setup check as it's a utility endpoint
+	Callback.AddUObject(this, &UGameFuseManager::HandleGetServerTimeResponse);
+	return RequestHandler->GetServerTime(Callback);
 }
 
 #pragma endregion
@@ -403,6 +418,22 @@ void UGameFuseManager::HandleForgotPasswordResponse(FGFAPIResponse Response)
 	}
 
 	UE_LOG(LogGameFuse, Log, TEXT("Forgot Password Email Sent!"));
+
+	// Execute the blueprint callback after all data is processed
+	ExecuteBlueprintCallback(Response);
+}
+
+void UGameFuseManager::HandleGetServerTimeResponse(FGFAPIResponse Response)
+{
+	if (!Response.bSuccess) {
+		UE_LOG(LogGameFuse, Warning, TEXT("GetServerTime Request Failed. ID : %s"), *Response.RequestId.ToString());
+		// Execute the blueprint callback even on failure
+		ExecuteBlueprintCallback(Response);
+		return;
+	}
+
+	// Use the utility function to parse server time
+	GameFuseUtilities::ConvertJsonToServerTime(GameData.ServerTime, Response.ResponseStr);
 
 	// Execute the blueprint callback after all data is processed
 	ExecuteBlueprintCallback(Response);

--- a/Source/GameFuse/Private/Subsystems/GameFuseManager.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseManager.cpp
@@ -204,7 +204,7 @@ FGuid UGameFuseManager::FetchLeaderboardEntries(const int Limit, bool bOnePerUse
 	if (!SetupCheck()) {
 		return FGuid();
 	}
-	const FGFUserData& UserData = GetGameInstance()->GetSubsystem<UGameFuseUser>()->GetLastFetchedUserData();
+	const FGFUserData& UserData = GetGameInstance()->GetSubsystem<UGameFuseUser>()->GetCurrentUserData();
 
 	Callback.AddUObject(this, &UGameFuseManager::HandleLeaderboardEntriesResponse);
 	return RequestHandler->FetchLeaderboardEntries(Limit, bOnePerUser, LeaderboardName, GameData.Id, UserData.AuthenticationToken, Callback);

--- a/Source/GameFuse/Private/Subsystems/GameFuseRounds.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseRounds.cpp
@@ -41,7 +41,7 @@ void UGameFuseRounds::BP_CreateGameRound(const FGFGameRound& GameRound, const FB
 FGuid UGameFuseRounds::CreateGameRound(const FGFGameRound& GameRound, FGFGameRoundCallback TypedCallback)
 {
 	if (const UGameFuseUser* User = GetGameInstance()->GetSubsystem<UGameFuseUser>()) {
-		return CreateGameRound(GameRound, User->GetUserData(), TypedCallback);
+		return CreateGameRound(GameRound, User->GetLastFetchedUserData(), TypedCallback);
 	}
 	return FGuid();
 }
@@ -75,7 +75,7 @@ FGuid UGameFuseRounds::FetchGameRound(const int32 RoundId, FGFGameRoundCallback 
 			HandleGameRoundResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->FetchGameRound(RoundId, User->GetUserData(), InternalCallback);
+		FGuid RequestId = RequestHandler->FetchGameRound(RoundId, User->GetLastFetchedUserData(), InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -99,7 +99,7 @@ FGuid UGameFuseRounds::UpdateGameRound(const int32 RoundId, const FGFGameRound& 
 			HandleGameRoundResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->UpdateGameRound(RoundId, User->GetUserData(), GameRound, InternalCallback);
+		FGuid RequestId = RequestHandler->UpdateGameRound(RoundId, User->GetLastFetchedUserData(), GameRound, InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -130,7 +130,7 @@ FGuid UGameFuseRounds::FetchMyGameRounds(FGFGameRoundListCallback TypedCallback,
 			HandleMyGameRoundListResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->FetchUserGameRounds(User->GetUserData().Id, User->GetUserData(), GameType, Page, PerPage, InternalCallback);
+		FGuid RequestId = RequestHandler->FetchUserGameRounds(User->GetLastFetchedUserData().Id, User->GetLastFetchedUserData(), GameType, Page, PerPage, InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundListCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -147,7 +147,7 @@ FGuid UGameFuseRounds::FetchUserGameRounds(int32 UserId, FGFGameRoundListCallbac
 			HandleUserGameRoundListResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->FetchUserGameRounds(UserId, User->GetUserData(), GameType, Page, PerPage, InternalCallback);
+		FGuid RequestId = RequestHandler->FetchUserGameRounds(UserId, User->GetLastFetchedUserData(), GameType, Page, PerPage, InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundListCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -171,7 +171,7 @@ FGuid UGameFuseRounds::DeleteGameRound(const int32 RoundId, FGFGameRoundActionCa
 			HandleDeleteResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->DeleteGameRound(RoundId, User->GetUserData(), InternalCallback);
+		FGuid RequestId = RequestHandler->DeleteGameRound(RoundId, User->GetLastFetchedUserData(), InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundActionCallbacks.Add(RequestId, TypedCallback);
 		}

--- a/Source/GameFuse/Private/Subsystems/GameFuseRounds.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseRounds.cpp
@@ -41,7 +41,7 @@ void UGameFuseRounds::BP_CreateGameRound(const FGFGameRound& GameRound, const FB
 FGuid UGameFuseRounds::CreateGameRound(const FGFGameRound& GameRound, FGFGameRoundCallback TypedCallback)
 {
 	if (const UGameFuseUser* User = GetGameInstance()->GetSubsystem<UGameFuseUser>()) {
-		return CreateGameRound(GameRound, User->GetLastFetchedUserData(), TypedCallback);
+		return CreateGameRound(GameRound, User->GetCurrentUserData(), TypedCallback);
 	}
 	return FGuid();
 }
@@ -75,7 +75,7 @@ FGuid UGameFuseRounds::FetchGameRound(const int32 RoundId, FGFGameRoundCallback 
 			HandleGameRoundResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->FetchGameRound(RoundId, User->GetLastFetchedUserData(), InternalCallback);
+		FGuid RequestId = RequestHandler->FetchGameRound(RoundId, User->GetCurrentUserData(), InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -99,7 +99,7 @@ FGuid UGameFuseRounds::UpdateGameRound(const int32 RoundId, const FGFGameRound& 
 			HandleGameRoundResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->UpdateGameRound(RoundId, User->GetLastFetchedUserData(), GameRound, InternalCallback);
+		FGuid RequestId = RequestHandler->UpdateGameRound(RoundId, User->GetCurrentUserData(), GameRound, InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -130,7 +130,7 @@ FGuid UGameFuseRounds::FetchMyGameRounds(FGFGameRoundListCallback TypedCallback,
 			HandleMyGameRoundListResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->FetchUserGameRounds(User->GetLastFetchedUserData().Id, User->GetLastFetchedUserData(), GameType, Page, PerPage, InternalCallback);
+		FGuid RequestId = RequestHandler->FetchUserGameRounds(User->GetCurrentUserData().Id, User->GetCurrentUserData(), GameType, Page, PerPage, InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundListCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -147,7 +147,7 @@ FGuid UGameFuseRounds::FetchUserGameRounds(int32 UserId, FGFGameRoundListCallbac
 			HandleUserGameRoundListResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->FetchUserGameRounds(UserId, User->GetLastFetchedUserData(), GameType, Page, PerPage, InternalCallback);
+		FGuid RequestId = RequestHandler->FetchUserGameRounds(UserId, User->GetCurrentUserData(), GameType, Page, PerPage, InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundListCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -171,7 +171,7 @@ FGuid UGameFuseRounds::DeleteGameRound(const int32 RoundId, FGFGameRoundActionCa
 			HandleDeleteResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->DeleteGameRound(RoundId, User->GetLastFetchedUserData(), InternalCallback);
+		FGuid RequestId = RequestHandler->DeleteGameRound(RoundId, User->GetCurrentUserData(), InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundActionCallbacks.Add(RequestId, TypedCallback);
 		}

--- a/Source/GameFuse/Private/Subsystems/GameFuseRounds.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseRounds.cpp
@@ -108,22 +108,46 @@ FGuid UGameFuseRounds::UpdateGameRound(const int32 RoundId, const FGFGameRound& 
 	return FGuid();
 }
 
-void UGameFuseRounds::BP_FetchUserGameRounds(const FBP_GFApiCallback& Callback)
+void UGameFuseRounds::BP_FetchMyGameRounds(const FString& GameType, int32 Page, int32 PerPage, const FBP_GFApiCallback& Callback)
 {
 	FGFGameRoundListCallback TypedCallback;
-	FGuid RequestId = FetchUserGameRounds(TypedCallback);
+	FGuid RequestId = FetchMyGameRounds(TypedCallback, GameType, Page, PerPage);
 	StoreBlueprintCallback(RequestId, Callback);
 }
 
-FGuid UGameFuseRounds::FetchUserGameRounds(FGFGameRoundListCallback TypedCallback)
+void UGameFuseRounds::BP_FetchUserGameRounds(int32 UserId, const FString& GameType, int32 Page, int32 PerPage, const FBP_GFApiCallback& Callback)
+{
+	FGFGameRoundListCallback TypedCallback;
+	FGuid RequestId = FetchUserGameRounds(UserId, TypedCallback, GameType, Page, PerPage);
+	StoreBlueprintCallback(RequestId, Callback);
+}
+
+FGuid UGameFuseRounds::FetchMyGameRounds(FGFGameRoundListCallback TypedCallback, const FString& GameType, int32 Page, int32 PerPage)
 {
 	if (const UGameFuseUser* User = GetGameInstance()->GetSubsystem<UGameFuseUser>()) {
 		FGFApiCallback InternalCallback;
 		InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
-			HandleGameRoundListResponse(Response);
+			HandleMyGameRoundListResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->FetchUserGameRounds(User->GetUserData(), InternalCallback);
+		FGuid RequestId = RequestHandler->FetchUserGameRounds(User->GetUserData().Id, User->GetUserData(), GameType, Page, PerPage, InternalCallback);
+		if (TypedCallback.IsBound()) {
+			GameRoundListCallbacks.Add(RequestId, TypedCallback);
+		}
+		return RequestId;
+	}
+	return FGuid();
+}
+
+FGuid UGameFuseRounds::FetchUserGameRounds(int32 UserId, FGFGameRoundListCallback TypedCallback, const FString& GameType, int32 Page, int32 PerPage)
+{
+	if (const UGameFuseUser* User = GetGameInstance()->GetSubsystem<UGameFuseUser>()) {
+		FGFApiCallback InternalCallback;
+		InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
+			HandleUserGameRoundListResponse(Response);
+		});
+
+		FGuid RequestId = RequestHandler->FetchUserGameRounds(UserId, User->GetUserData(), GameType, Page, PerPage, InternalCallback);
 		if (TypedCallback.IsBound()) {
 			GameRoundListCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -207,7 +231,7 @@ void UGameFuseRounds::HandleGameRoundResponse(FGFAPIResponse Response)
 	}
 }
 
-void UGameFuseRounds::HandleGameRoundListResponse(FGFAPIResponse Response)
+void UGameFuseRounds::HandleMyGameRoundListResponse(FGFAPIResponse Response)
 {
 	// Execute the blueprint callback regardless of success
 	ExecuteBlueprintCallback(Response);
@@ -234,6 +258,40 @@ void UGameFuseRounds::HandleGameRoundListResponse(FGFAPIResponse Response)
 
 	if (GameRoundListCallbacks.Contains(Response.RequestId)) {
 		GameRoundListCallbacks[Response.RequestId].ExecuteIfBound(UserGameRounds);
+		GameRoundListCallbacks.Remove(Response.RequestId);
+	}
+}
+
+void UGameFuseRounds::HandleUserGameRoundListResponse(FGFAPIResponse Response)
+{
+	ExecuteBlueprintCallback(Response);
+
+	if (!Response.bSuccess)
+	{
+		UE_LOG(LogGameFuse, Error, TEXT("Failed to handle game round list response: %s"), *Response.ResponseStr);
+		if (GameRoundListCallbacks.Contains(Response.RequestId))
+		{
+			GameRoundListCallbacks[Response.RequestId].ExecuteIfBound(TArray<FGFGameRound>());
+			GameRoundListCallbacks.Remove(Response.RequestId);
+		}
+		return;
+	}
+
+	TArray<FGFGameRound> GameRounds;
+	if (!GameFuseUtilities::ConvertJsonToGameRounds(GameRounds, Response.ResponseStr))
+	{
+		UE_LOG(LogGameFuse, Error, TEXT("Failed to parse game rounds from response"));
+		if (GameRoundListCallbacks.Contains(Response.RequestId))
+		{
+			GameRoundListCallbacks[Response.RequestId].ExecuteIfBound(TArray<FGFGameRound>());
+			GameRoundListCallbacks.Remove(Response.RequestId);
+		}
+		return;
+	}
+
+	if (GameRoundListCallbacks.Contains(Response.RequestId))
+	{
+		GameRoundListCallbacks[Response.RequestId].ExecuteIfBound(GameRounds);
 		GameRoundListCallbacks.Remove(Response.RequestId);
 	}
 }

--- a/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
@@ -190,19 +190,28 @@ FGuid UGameFuseUser::RemoveStoreItem(const int32 StoreItemId, FGFStoreItemsCallb
 	return RequestId;
 }
 
-FGuid UGameFuseUser::FetchPurchasedStoreItems(FGFStoreItemsCallback TypedCallback)
+FGuid UGameFuseUser::FetchMyPurchasedStoreItems(FGFStoreItemsCallback TypedCallback)
+{
+	return FetchUserPurchasedStoreItems(UserData.Id, TypedCallback);
+}
+
+FGuid UGameFuseUser::FetchUserPurchasedStoreItems(const int32 UserId, FGFStoreItemsCallback TypedCallback)
 {
 	FGFApiCallback InternalCallback;
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
 		HandleStoreItemsResponse(Response);
 	});
+	FGFUserData TempUser;
+	TempUser.Id = UserId;
+	TempUser.AuthenticationToken = UserData.AuthenticationToken;
 
-	FGuid RequestId = RequestHandler->FetchPurchasedStoreItems(UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->FetchPurchasedStoreItems(TempUser, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		StoreItemsCallbacks.Add(RequestId, TypedCallback);
 	}
 	return RequestId;
 }
+
 
 #pragma endregion
 
@@ -277,14 +286,23 @@ FGuid UGameFuseUser::RemoveAttribute(const FString& SetKey, FGFAttributesCallbac
 	return RequestId;
 }
 
-FGuid UGameFuseUser::FetchAttributes(FGFAttributesCallback TypedCallback)
+FGuid UGameFuseUser::FetchMyAttributes(FGFAttributesCallback TypedCallback)
+{
+	return FetchUserAttributes(UserData.Id, TypedCallback);
+}
+
+FGuid UGameFuseUser::FetchUserAttributes(const int32 UserId, FGFAttributesCallback TypedCallback)
 {
 	FGFApiCallback InternalCallback;
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
 		HandleAttributesResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchAttributes(UserData, InternalCallback);
+	FGFUserData TempUser;
+	TempUser.Id = UserId;
+	TempUser.AuthenticationToken = UserData.AuthenticationToken;
+
+	FGuid RequestId = RequestHandler->FetchAttributes(TempUser, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		AttributesCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -401,12 +419,25 @@ FGuid UGameFuseUser::ClearLeaderboardEntry(const FString& LeaderboardName, FGFIn
 
 FGuid UGameFuseUser::FetchMyLeaderboardEntries(const int32 Limit, bool bOnePerUser, FGFLeaderboardEntriesCallback TypedCallback)
 {
+	return FetchUserLeaderboardEntries(UserData.Id, Limit, bOnePerUser, TypedCallback);
+}
+
+FGuid UGameFuseUser::FetchUserLeaderboardEntries(const int32 UserId, const int32 Limit, bool bOnePerUser, FGFLeaderboardEntriesCallback TypedCallback)
+{
 	FGFApiCallback InternalCallback;
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
 		HandleLeaderboardEntriesResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->FetchMyLeaderboardEntries(Limit, bOnePerUser, UserData, InternalCallback);
+	FGFUserData TempUser;
+	TempUser.Id = UserId;
+
+	TempUser.AuthenticationToken = UserData.AuthenticationToken;
+
+	// might be better to change the RequestHandler to take in exactly what it needs (userdId, and authToken)
+	// this temp user data is technically data from two different users, current users' auth token and the userId of the user we want to fetch
+
+	FGuid RequestId = RequestHandler->FetchLeaderboardEntries(Limit, bOnePerUser, TempUser, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		LeaderboardEntriesCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -495,10 +526,19 @@ void UGameFuseUser::BP_RemoveAttribute(const FString& Key, FBP_GFApiCallback Cal
 	}
 }
 
-void UGameFuseUser::BP_FetchPurchasedStoreItems(FBP_GFApiCallback Callback)
+void UGameFuseUser::BP_FetchMyPurchasedStoreItems(FBP_GFApiCallback Callback)
 {
 	FGFStoreItemsCallback TypedCallback;
-	FGuid RequestId = FetchPurchasedStoreItems(TypedCallback);
+	FGuid RequestId = FetchMyPurchasedStoreItems(TypedCallback);
+	if (Callback.IsBound()) {
+		BlueprintCallbacks.Add(RequestId, Callback);
+	}
+}
+
+void UGameFuseUser::BP_FetchUserPurchasedStoreItems(const int32 UserId, FBP_GFApiCallback Callback)
+{
+	FGFStoreItemsCallback TypedCallback;
+	FGuid RequestId = FetchUserPurchasedStoreItems(UserId, TypedCallback);
 	if (Callback.IsBound()) {
 		BlueprintCallbacks.Add(RequestId, Callback);
 	}
@@ -549,10 +589,19 @@ void UGameFuseUser::BP_ClearLeaderboardEntry(const FString& LeaderboardName, FBP
 	}
 }
 
-void UGameFuseUser::BP_FetchAttributes(FBP_GFApiCallback Callback)
+void UGameFuseUser::BP_FetchMyAttributes(FBP_GFApiCallback Callback)
 {
 	FGFAttributesCallback TypedCallback;
-	FGuid RequestId = FetchAttributes(TypedCallback);
+	FGuid RequestId = FetchMyAttributes(TypedCallback);
+	if (Callback.IsBound()) {
+		BlueprintCallbacks.Add(RequestId, Callback);
+	}
+}
+
+void UGameFuseUser::BP_FetchUserAttributes(int32 UserId, FBP_GFApiCallback Callback)
+{
+	FGFAttributesCallback TypedCallback;
+	FGuid RequestId = FetchUserAttributes(UserId, TypedCallback);
 	if (Callback.IsBound()) {
 		BlueprintCallbacks.Add(RequestId, Callback);
 	}
@@ -562,6 +611,15 @@ void UGameFuseUser::BP_FetchMyLeaderboardEntries(const int32 Limit, bool bOnePer
 {
 	FGFLeaderboardEntriesCallback TypedCallback;
 	FGuid RequestId = FetchMyLeaderboardEntries(Limit, bOnePerUser, TypedCallback);
+	if (Callback.IsBound()) {
+		BlueprintCallbacks.Add(RequestId, Callback);
+	}
+}
+
+void UGameFuseUser::BP_FetchUserLeaderboardEntries(const int32 UserId, const int32 Limit, bool bOnePerUser, FBP_GFApiCallback Callback)
+{
+	FGFLeaderboardEntriesCallback TypedCallback;
+	FGuid RequestId = FetchUserLeaderboardEntries(UserId, Limit, bOnePerUser, TypedCallback);
 	if (Callback.IsBound()) {
 		BlueprintCallbacks.Add(RequestId, Callback);
 	}

--- a/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
@@ -21,8 +21,18 @@ void UGameFuseUser::Initialize(FSubsystemCollectionBase& Collection)
 
 	RequestHandler = NewObject<UUserAPIHandler>();
 	if (const UGameFuseSaveData* LoadedSaveGame = Cast<UGameFuseSaveData>(UGameplayStatics::LoadGameFromSlot("GameFuseSaveSlot", 0))) {
-		LastFetchedUserData = LoadedSaveGame->UserData;
-		UE_LOG(LogGameFuse, Log, TEXT("Game Fuse Subsystem Loaded"));
+		CurrentUserData = LoadedSaveGame->UserData;
+		
+		// Validate that we have a valid authentication token for the loaded user data
+		if (CurrentUserData.AuthenticationToken.IsEmpty()) {
+			UE_LOG(LogGameFuse, Warning, TEXT("Loaded user data has no authentication token - user will need to sign in again"));
+			CurrentUserData.bSignedIn = false;
+		} else {
+			UE_LOG(LogGameFuse, Log, TEXT("Game Fuse Subsystem Loaded with valid authentication token"));
+			CurrentUserData.bSignedIn = true;
+		}
+	} else {
+		UE_LOG(LogGameFuse, Log, TEXT("No saved user data found - user will need to sign in"));
 	}
 
 	GameFuseManager = GetGameInstance()->GetSubsystem<UGameFuseManager>();

--- a/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
@@ -107,6 +107,20 @@ FGuid UGameFuseUser::SignIn(const FGFGameData& GameData, const FString& Email, c
 	return RequestId;
 }
 
+FGuid UGameFuseUser::FetchUser(const int32 UserId, FGFUserDataCallback TypedCallback)
+{
+	FGFApiCallback InternalCallback;
+	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
+		HandleUserDataResponse(Response, true);
+	});
+
+	FGuid RequestId = RequestHandler->FetchUser(UserId, InternalCallback);
+	if (TypedCallback.IsBound()) {
+		UserDataCallbacks.Add(RequestId, TypedCallback);
+	}
+	return RequestId;
+}
+
 void UGameFuseUser::LogOut(const FString& SaveSlotName)
 {
 	UE_LOG(LogGameFuse, Log, TEXT("User %i Logging Out"), UserData.Id);

--- a/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
@@ -21,7 +21,7 @@ void UGameFuseUser::Initialize(FSubsystemCollectionBase& Collection)
 
 	RequestHandler = NewObject<UUserAPIHandler>();
 	if (const UGameFuseSaveData* LoadedSaveGame = Cast<UGameFuseSaveData>(UGameplayStatics::LoadGameFromSlot("GameFuseSaveSlot", 0))) {
-		UserData = LoadedSaveGame->UserData;
+		LastFetchedUserData = LoadedSaveGame->UserData;
 		UE_LOG(LogGameFuse, Log, TEXT("Game Fuse Subsystem Loaded"));
 	}
 
@@ -37,34 +37,39 @@ void UGameFuseUser::Deinitialize()
 
 #pragma region Core User Data & Authentication
 
-const FGFUserData& UGameFuseUser::GetUserData() const
+const FGFUserData& UGameFuseUser::GetCurrentUserData() const
 {
-	return UserData;
+	return CurrentUserData;
+}
+
+const FGFUserData& UGameFuseUser::GetLastFetchedUserData() const
+{
+	return LastFetchedUserData;
 }
 
 bool UGameFuseUser::IsSignedIn() const
 {
-	return UserData.bSignedIn;
+	return CurrentUserData.bSignedIn;
 }
 
 int32 UGameFuseUser::GetNumberOfLogins() const
 {
-	return UserData.NumberOfLogins;
+	return CurrentUserData.NumberOfLogins;
 }
 
 FString UGameFuseUser::GetLastLogin() const
 {
-	return UserData.LastLogin;
+	return CurrentUserData.LastLogin;
 }
 
 FString UGameFuseUser::GetUsername() const
 {
-	return UserData.Username;
+	return CurrentUserData.Username;
 }
 
 FString UGameFuseUser::GetAuthenticationToken() const
 {
-	return UserData.AuthenticationToken;
+	return CurrentUserData.AuthenticationToken;
 }
 
 FGuid UGameFuseUser::SignUp(const FString& Email, const FString& Password, const FString& PasswordConfirmation, const FString& Username, FGFUserDataCallback TypedCallback)
@@ -111,7 +116,7 @@ FGuid UGameFuseUser::FetchUser(const int32 UserId, FGFUserDataCallback TypedCall
 {
 	FGFApiCallback InternalCallback;
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
-		HandleUserDataResponse(Response, true);
+		HandleUserDataResponse(Response, false);
 	});
 
 	FGuid RequestId = RequestHandler->FetchUser(UserId, InternalCallback);
@@ -123,8 +128,15 @@ FGuid UGameFuseUser::FetchUser(const int32 UserId, FGFUserDataCallback TypedCall
 
 void UGameFuseUser::LogOut(const FString& SaveSlotName)
 {
-	UE_LOG(LogGameFuse, Log, TEXT("User %i Logging Out"), UserData.Id);
-	UserData = FGFUserData();
+	UE_LOG(LogGameFuse, Log, TEXT("User %i Logging Out"), CurrentUserData.Id);
+	
+	// Clear all user data
+	CurrentUserData = FGFUserData();
+	LastFetchedUserData = FGFUserData();
+	Attributes.Empty();
+	LocalAttributes.Empty();
+	PurchasedStoreItems.Empty();
+	LeaderboardEntries.Empty();
 
 	if (UGameplayStatics::DoesSaveGameExist(SaveSlotName, 0)) {
 		UGameplayStatics::DeleteGameInSlot(SaveSlotName, 0);
@@ -140,7 +152,7 @@ void UGameFuseUser::LogOut(const FString& SaveSlotName)
 
 int32 UGameFuseUser::GetCredits() const
 {
-	return UserData.Credits;
+	return CurrentUserData.Credits;
 }
 
 const TArray<FGFStoreItem>& UGameFuseUser::GetPurchasedStoreItems() const
@@ -152,10 +164,10 @@ FGuid UGameFuseUser::AddCredits(const int32 AddCredits, FGFUserDataCallback Type
 {
 	FGFApiCallback InternalCallback;
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
-		HandleUserDataResponse(Response);
+		HandleUserDataResponse(Response, true);
 	});
 
-	FGuid RequestId = RequestHandler->AddCredits(AddCredits, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->AddCredits(AddCredits, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		UserDataCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -166,10 +178,10 @@ FGuid UGameFuseUser::SetCredits(const int32 SetCredits, FGFUserDataCallback Type
 {
 	FGFApiCallback InternalCallback;
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
-		HandleUserDataResponse(Response);
+		HandleUserDataResponse(Response, true);
 	});
 
-	FGuid RequestId = RequestHandler->SetCredits(SetCredits, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->SetCredits(SetCredits, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		UserDataCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -183,7 +195,7 @@ FGuid UGameFuseUser::PurchaseStoreItem(const int32 StoreItemId, FGFStoreItemsCal
 		HandleStoreItemsResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->PurchaseStoreItem(StoreItemId, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->PurchaseStoreItem(StoreItemId, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		StoreItemsCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -197,7 +209,7 @@ FGuid UGameFuseUser::RemoveStoreItem(const int32 StoreItemId, FGFStoreItemsCallb
 		HandleUserActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RemoveStoreItem(StoreItemId, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->RemoveStoreItem(StoreItemId, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		StoreItemsCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -206,7 +218,7 @@ FGuid UGameFuseUser::RemoveStoreItem(const int32 StoreItemId, FGFStoreItemsCallb
 
 FGuid UGameFuseUser::FetchMyPurchasedStoreItems(FGFStoreItemsCallback TypedCallback)
 {
-	return FetchUserPurchasedStoreItems(UserData.Id, TypedCallback);
+	return FetchUserPurchasedStoreItems(CurrentUserData.Id, TypedCallback);
 }
 
 FGuid UGameFuseUser::FetchUserPurchasedStoreItems(const int32 UserId, FGFStoreItemsCallback TypedCallback)
@@ -217,7 +229,7 @@ FGuid UGameFuseUser::FetchUserPurchasedStoreItems(const int32 UserId, FGFStoreIt
 	});
 	FGFUserData TempUser;
 	TempUser.Id = UserId;
-	TempUser.AuthenticationToken = UserData.AuthenticationToken;
+	TempUser.AuthenticationToken = CurrentUserData.AuthenticationToken;
 
 	FGuid RequestId = RequestHandler->FetchPurchasedStoreItems(TempUser, InternalCallback);
 	if (TypedCallback.IsBound()) {
@@ -260,13 +272,12 @@ FGuid UGameFuseUser::SetAttribute(const FString& Key, const FString& Value, FGFA
 		HandleAttributesResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->SetAttribute(Key, Value, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->SetAttribute(Key, Value, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		AttributesCallbacks.Add(RequestId, TypedCallback);
 	}
 	return RequestId;
 }
-
 
 FGuid UGameFuseUser::SetAttributes(const TMap<FString, FString>& NewAttributes, FGFAttributesCallback TypedCallback)
 {
@@ -275,7 +286,7 @@ FGuid UGameFuseUser::SetAttributes(const TMap<FString, FString>& NewAttributes, 
 		HandleAttributesResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->SetAttributes(NewAttributes, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->SetAttributes(NewAttributes, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		AttributesCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -296,13 +307,16 @@ FGuid UGameFuseUser::RemoveAttribute(const FString& SetKey, FGFAttributesCallbac
 		HandleAttributesResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RemoveAttribute(SetKey, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->RemoveAttribute(SetKey, CurrentUserData, InternalCallback);
+	if (TypedCallback.IsBound()) {
+		AttributesCallbacks.Add(RequestId, TypedCallback);
+	}
 	return RequestId;
 }
 
 FGuid UGameFuseUser::FetchMyAttributes(FGFAttributesCallback TypedCallback)
 {
-	return FetchUserAttributes(UserData.Id, TypedCallback);
+	return FetchUserAttributes(CurrentUserData.Id, TypedCallback);
 }
 
 FGuid UGameFuseUser::FetchUserAttributes(const int32 UserId, FGFAttributesCallback TypedCallback)
@@ -314,7 +328,7 @@ FGuid UGameFuseUser::FetchUserAttributes(const int32 UserId, FGFAttributesCallba
 
 	FGFUserData TempUser;
 	TempUser.Id = UserId;
-	TempUser.AuthenticationToken = UserData.AuthenticationToken;
+	TempUser.AuthenticationToken = CurrentUserData.AuthenticationToken;
 
 	FGuid RequestId = RequestHandler->FetchAttributes(TempUser, InternalCallback);
 	if (TypedCallback.IsBound()) {
@@ -332,7 +346,7 @@ FGuid UGameFuseUser::SyncLocalAttributes(FGFAttributesCallback TypedCallback)
 			HandleAttributesResponse(Response);
 		});
 
-		FGuid RequestId = RequestHandler->FetchAttributes(UserData, InternalCallback);
+		FGuid RequestId = RequestHandler->FetchAttributes(CurrentUserData, InternalCallback);
 		if (TypedCallback.IsBound()) {
 			AttributesCallbacks.Add(RequestId, TypedCallback);
 		}
@@ -349,7 +363,7 @@ FGuid UGameFuseUser::SyncLocalAttributes(FGFAttributesCallback TypedCallback)
 		HandleAttributesResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->SetAttributes(LocalAttributes, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->SetAttributes(LocalAttributes, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		AttributesCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -363,7 +377,7 @@ FGuid UGameFuseUser::RemoveAttributes(const TArray<FString>& AttributeKeys, FGFA
 		HandleAttributesResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->RemoveAttributes(AttributeKeys, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->RemoveAttributes(AttributeKeys, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		AttributesCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -376,10 +390,10 @@ FGuid UGameFuseUser::RemoveAttributes(const TArray<FString>& AttributeKeys, FGFA
 
 int32 UGameFuseUser::GetScore() const
 {
-	return UserData.Score;
+	return CurrentUserData.Score;
 }
 
-const TArray<FGFLeaderboardEntry>& UGameFuseUser::GetMyLeaderboardEntries() const
+const TArray<FGFLeaderboardEntry>& UGameFuseUser::GetLeaderboardEntries() const
 {
 	return LeaderboardEntries;
 }
@@ -388,10 +402,10 @@ FGuid UGameFuseUser::AddScore(const int32 AddScore, FGFUserDataCallback TypedCal
 {
 	FGFApiCallback InternalCallback;
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
-		HandleUserDataResponse(Response);
+		HandleUserDataResponse(Response, true);
 	});
 
-	FGuid RequestId = RequestHandler->AddScore(AddScore, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->AddScore(AddScore, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		UserDataCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -402,10 +416,10 @@ FGuid UGameFuseUser::SetScore(const int32 SetScore, FGFUserDataCallback TypedCal
 {
 	FGFApiCallback InternalCallback;
 	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
-		HandleUserDataResponse(Response);
+		HandleUserDataResponse(Response, true);
 	});
 
-	FGuid RequestId = RequestHandler->SetScore(SetScore, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->SetScore(SetScore, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		UserDataCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -419,7 +433,7 @@ FGuid UGameFuseUser::AddLeaderboardEntry(const FString& LeaderboardName, const i
 		HandleUserActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->AddLeaderboardEntry(LeaderboardName, Score, Metadata, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->AddLeaderboardEntry(LeaderboardName, Score, Metadata, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		SimpleSuccessCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -438,7 +452,7 @@ FGuid UGameFuseUser::ClearLeaderboardEntry(const FString& LeaderboardName, FGFIn
 		HandleUserActionResponse(Response);
 	});
 
-	FGuid RequestId = RequestHandler->ClearLeaderboardEntry(LeaderboardName, UserData, InternalCallback);
+	FGuid RequestId = RequestHandler->ClearLeaderboardEntry(LeaderboardName, CurrentUserData, InternalCallback);
 	if (TypedCallback.IsBound()) {
 		SimpleSuccessCallbacks.Add(RequestId, TypedCallback);
 	}
@@ -447,7 +461,7 @@ FGuid UGameFuseUser::ClearLeaderboardEntry(const FString& LeaderboardName, FGFIn
 
 FGuid UGameFuseUser::FetchMyLeaderboardEntries(const int32 Limit, bool bOnePerUser, FGFLeaderboardEntriesCallback TypedCallback)
 {
-	return FetchUserLeaderboardEntries(UserData.Id, Limit, bOnePerUser, TypedCallback);
+	return FetchUserLeaderboardEntries(CurrentUserData.Id, Limit, bOnePerUser, TypedCallback);
 }
 
 FGuid UGameFuseUser::FetchUserLeaderboardEntries(const int32 UserId, const int32 Limit, bool bOnePerUser, FGFLeaderboardEntriesCallback TypedCallback)
@@ -459,11 +473,7 @@ FGuid UGameFuseUser::FetchUserLeaderboardEntries(const int32 UserId, const int32
 
 	FGFUserData TempUser;
 	TempUser.Id = UserId;
-
-	TempUser.AuthenticationToken = UserData.AuthenticationToken;
-
-	// might be better to change the RequestHandler to take in exactly what it needs (userdId, and authToken)
-	// this temp user data is technically data from two different users, current users' auth token and the userId of the user we want to fetch
+	TempUser.AuthenticationToken = CurrentUserData.AuthenticationToken;
 
 	FGuid RequestId = RequestHandler->FetchLeaderboardEntries(Limit, bOnePerUser, TempUser, InternalCallback);
 	if (TypedCallback.IsBound()) {
@@ -685,7 +695,7 @@ void UGameFuseUser::BP_RemoveAttributes(const TArray<FString>& AttributeKeys, FB
 
 #pragma region Response Handlers
 
-bool UGameFuseUser::HandleUserDataResponse(FGFAPIResponse Response, bool bLogIn)
+bool UGameFuseUser::HandleUserDataResponse(FGFAPIResponse Response, bool bUpdateCurrentUser)
 {
 	if (!Response.bSuccess) {
 		UE_LOG(LogGameFuse, Error, TEXT("User data response failed: %s"), *Response.ResponseStr);
@@ -709,29 +719,44 @@ bool UGameFuseUser::HandleUserDataResponse(FGFAPIResponse Response, bool bLogIn)
 		return false;
 	}
 
-	// Update the stored user data
-	if (bLogIn) {
-		UserData = NewUserData;
-		UserData.bSignedIn = true;
-		UE_LOG(LogGameFuse, Warning, TEXT("Successfully signed in user token: %s"), *UserData.AuthenticationToken);
+	// Update the appropriate user data based on the flag
+	if (bUpdateCurrentUser) {
+		// Update current user data (for sign in/up operations)
+		// Preserve existing authentication token if the new data doesn't have one
+		FString ExistingAuthToken = CurrentUserData.AuthenticationToken;
+		CurrentUserData = NewUserData;
+		
+		// If the new data doesn't have an auth token, keep the existing one
+		if (CurrentUserData.AuthenticationToken.IsEmpty() && !ExistingAuthToken.IsEmpty()) {
+			CurrentUserData.AuthenticationToken = ExistingAuthToken;
+		}
+		
+		CurrentUserData.bSignedIn = true;
+		UE_LOG(LogGameFuse, Warning, TEXT("Successfully signed in user token: %s"), *CurrentUserData.AuthenticationToken);
 
 		UE_LOG(LogGameFuse, Log, TEXT("Saved Login Data Into SlotName:GameFuseSaveSlot UserIndex:0"));
+		
+		// Also update last fetched user data to match current user data
+		LastFetchedUserData = CurrentUserData;
 	} else {
-		// dont update authentication tokeen
-		FString CachedToken = UserData.AuthenticationToken;
-		UserData = NewUserData;
-		UserData.AuthenticationToken = CachedToken;
-		UserData.bSignedIn = true;
+		// Update last fetched user data (for fetch operations)
+		// Never store authentication token for fetched users
+		LastFetchedUserData = NewUserData;
+		LastFetchedUserData.AuthenticationToken = TEXT(""); // Clear auth token for fetched users
+		LastFetchedUserData.bSignedIn = false; // Fetched users are not signed in
 	}
 
+	// Save current user data to persistent storage
 	UGameFuseSaveData* SaveGameInstance = Cast<UGameFuseSaveData>(UGameplayStatics::CreateSaveGameObject(UGameFuseSaveData::StaticClass()));
-	SaveGameInstance->UserData = UserData;
+	SaveGameInstance->UserData = CurrentUserData;
 
 	UGameplayStatics::SaveGameToSlot(SaveGameInstance, "GameFuseSaveSlot", 0);
 
 	// Execute the specific callback for this request if it exists
+	// For current user operations, return CurrentUserData; for fetch operations, return LastFetchedUserData
+	FGFUserData CallbackData = bUpdateCurrentUser ? CurrentUserData : LastFetchedUserData;
 	if (UserDataCallbacks.Contains(Response.RequestId)) {
-		UserDataCallbacks[Response.RequestId].Execute(true, UserData);
+		UserDataCallbacks[Response.RequestId].Execute(true, CallbackData);
 		UserDataCallbacks.Remove(Response.RequestId);
 	}
 

--- a/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
+++ b/Source/GameFuse/Private/Subsystems/GameFuseUser.cpp
@@ -356,6 +356,20 @@ FGuid UGameFuseUser::SyncLocalAttributes(FGFAttributesCallback TypedCallback)
 	return RequestId;
 }
 
+FGuid UGameFuseUser::RemoveAttributes(const TArray<FString>& AttributeKeys, FGFAttributesCallback TypedCallback)
+{
+	FGFApiCallback InternalCallback;
+	InternalCallback.AddLambda([this](const FGFAPIResponse& Response) {
+		HandleAttributesResponse(Response);
+	});
+
+	FGuid RequestId = RequestHandler->RemoveAttributes(AttributeKeys, UserData, InternalCallback);
+	if (TypedCallback.IsBound()) {
+		AttributesCallbacks.Add(RequestId, TypedCallback);
+	}
+	return RequestId;
+}
+
 #pragma endregion
 
 #pragma region Leaderboard & Score
@@ -653,6 +667,16 @@ void UGameFuseUser::BP_SetAttributes(const TMap<FString, FString>& NewAttributes
 	FGFAttributesCallback TypedCallback;
 	FGuid RequestId = SetAttributes(NewAttributes, TypedCallback);
 	if (Callback.IsBound()) {
+		BlueprintCallbacks.Add(RequestId, Callback);
+	}
+}
+
+void UGameFuseUser::BP_RemoveAttributes(const TArray<FString>& AttributeKeys, FBP_GFApiCallback Callback)
+{
+	FGFAttributesCallback TypedCallback;
+	FGuid RequestId = RemoveAttributes(AttributeKeys, TypedCallback);
+	if (Callback.IsBound())
+	{
 		BlueprintCallbacks.Add(RequestId, Callback);
 	}
 }

--- a/Source/GameFuse/Public/API/CoreAPIHandler.h
+++ b/Source/GameFuse/Public/API/CoreAPIHandler.h
@@ -40,6 +40,8 @@ public:
 
 	FGuid FetchStoreItems(int GameID, const FString& Token, const FGFApiCallback& Callback);
 
+	FGuid GetServerTime(const FGFApiCallback& Callback);
+
 	// UFUNCTION()
 	// void OnHTTPResponseManager(bool bSuccess, FString ResponseContent, FString RequestId);
 

--- a/Source/GameFuse/Public/API/FriendsAPIHandler.h
+++ b/Source/GameFuse/Public/API/FriendsAPIHandler.h
@@ -31,8 +31,11 @@ public:
 	/** Retrieve the list of friends, outgoing, and incoming friendship requests for the current user. */
 	FGuid GetFriendshipData(const FGFUserData& UserData, const FGFApiCallback& Callback);
 
-	// Get friends list
-	FGuid GetFriendsList(const FGFUserData& UserData, const FGFApiCallback& Callback);
+	// Get your friends list
+	FGuid GetMyFriendsList(const FGFUserData& UserData, const FGFApiCallback& Callback);
+
+	// Get another user's friends list
+	FGuid GetUserFriendsList(int32 UserId, const FGFUserData& UserData, const FGFApiCallback& Callback);
 
 	// Get outgoing friend requests
 	FGuid GetOutgoingFriendRequests(const FGFUserData& UserData, const FGFApiCallback& Callback);

--- a/Source/GameFuse/Public/API/GroupsAPIHandler.h
+++ b/Source/GameFuse/Public/API/GroupsAPIHandler.h
@@ -77,6 +77,15 @@ public:
 	FGuid FetchAllGroups(const FGFUserData& UserData, const FGFApiCallback& Callback);
 	FGuid RequestToJoinGroup(int32 GroupId, const FGFUserData& UserData, const FGFApiCallback& Callback);
 
+	/**
+	 * Invites a user to join a group
+	 * @param GroupId The ID of the group to invite the user to
+	 * @param UserIdToInvite The ID of the user to invite
+	 * @param UserData The user data of the requester (must be admin of the group)
+	 * @param Callback The callback to handle the response
+	 */
+	FGuid InviteGroupMember(int32 GroupId, int32 UserIdToInvite, const FGFUserData& UserData, const FGFApiCallback& Callback);
+
 	// Respond to a group join request
 	FGuid RespondToGroupJoinRequest(const int32 ConnectionId, const int32 UserId, EGFInviteRequestStatus Status, const FGFUserData& UserData, const FGFApiCallback& Callback);
 };

--- a/Source/GameFuse/Public/API/GroupsAPIHandler.h
+++ b/Source/GameFuse/Public/API/GroupsAPIHandler.h
@@ -47,11 +47,11 @@ public:
 	 * Add an attribute to a group
 	 * @param GroupId - The ID of the group to add the attribute to
 	 * @param Attribute - The attribute to add, GroupId and bCanEdit are read only and ignored for this request
-	 * @param bOnlyCreatorCanEdit - Whether only the creator can edit this attribute
+	 * @param bOthersCanEdit - Whether only the creator can edit this attribute
 	 * @param UserData - The user data of the requester
 	 * @param Callback - The callback to handle the response
 	 */
-	FGuid AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOnlyCreatorCanEdit, const FGFUserData& UserData, const FGFApiCallback& Callback);
+	FGuid AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOthersCanEdit, const FGFUserData& UserData, const FGFApiCallback& Callback);
 
 	/**
 	 * Fetch all attributes for a group

--- a/Source/GameFuse/Public/API/RoundsAPIHandler.h
+++ b/Source/GameFuse/Public/API/RoundsAPIHandler.h
@@ -26,7 +26,7 @@ public:
 	                      const FGFGameRound& GameRound, const FGFApiCallback& Callback);
 
 	// Fetch user's game rounds
-	FGuid FetchUserGameRounds(const FGFUserData& UserData, const FGFApiCallback& Callback);
+	FGuid FetchUserGameRounds(int32 UserId, const FGFUserData& UserData, const FString& GameType, int32 Page, int32 PerPage, const FGFApiCallback& Callback);
 
 	// Delete a game round
 	FGuid DeleteGameRound(const int32 RoundId, const FGFUserData& UserData, const FGFApiCallback& Callback);

--- a/Source/GameFuse/Public/API/UserAPIHandler.h
+++ b/Source/GameFuse/Public/API/UserAPIHandler.h
@@ -18,6 +18,7 @@ public:
 
 	FGuid SignUp(const FString& Email, const FString& Password, const FString& PasswordConfirmation, const FString& Username, const int InGameId, const FString& InToken, const FGFApiCallback& Callback);
 	FGuid SignIn(const FString& Email, const FString& Password, const int InGameId, const FString& InToken, const FGFApiCallback& Callback);
+	FGuid FetchUser(int32 UserId, const FGFApiCallback& InternalCallback);
 
 	//> User Requests
 	FGuid AddCredits(const int32 Credits, const FGFUserData& UserData, const FGFApiCallback& Callback);

--- a/Source/GameFuse/Public/API/UserAPIHandler.h
+++ b/Source/GameFuse/Public/API/UserAPIHandler.h
@@ -28,6 +28,7 @@ public:
 	FGuid SetAttribute(const FString& Key, const FString& Value, const FGFUserData& UserData, const FGFApiCallback& Callback);
 	FGuid SetAttributes(const TMap<FString, FString>& Attributes, const FGFUserData& UserData, const FGFApiCallback& Callback);
 	FGuid RemoveAttribute(const FString& Key, const FGFUserData& UserData, const FGFApiCallback& Callback);
+	FGuid RemoveAttributes(const TArray<FString>& AttributeKeys, const FGFUserData& UserData, const FGFApiCallback& Callback);
 	FGuid PurchaseStoreItem(const int32 StoreItemId, const FGFUserData& UserData, const FGFApiCallback& Callback);
 	FGuid RemoveStoreItem(const int32 StoreItemId, const FGFUserData& UserData, const FGFApiCallback& Callback);
 	FGuid AddLeaderboardEntry(const FString& LeaderboardName, const int32 Score, const TMap<FString, FString>& Metadata, const FGFUserData& UserData, const FGFApiCallback& Callback);

--- a/Source/GameFuse/Public/API/UserAPIHandler.h
+++ b/Source/GameFuse/Public/API/UserAPIHandler.h
@@ -38,7 +38,7 @@ public:
 	FGuid ClearLeaderboardEntry(const FString& LeaderboardName, const FGFUserData& UserData, const FGFApiCallback& Callback);
 
 	//> Action Requests
-	FGuid FetchMyLeaderboardEntries(const int32 Limit, bool bOnePerUser, const FGFUserData& UserData, const FGFApiCallback& Callback);
+	FGuid FetchLeaderboardEntries(const int32 Limit, bool bOnePerUser, const FGFUserData& UserData, const FGFApiCallback& Callback);
 	FGuid FetchAttributes(const FGFUserData& UserData, const FGFApiCallback& Callback);
 	FGuid FetchPurchasedStoreItems(const FGFUserData& UserData, const FGFApiCallback& Callback);
 

--- a/Source/GameFuse/Public/Library/GameFuseStructLibrary.h
+++ b/Source/GameFuse/Public/Library/GameFuseStructLibrary.h
@@ -13,7 +13,7 @@
 
 // Add this new struct to the file
 USTRUCT(BlueprintType, Category = "GameFuse|GameData")
-struct FGFGameData
+struct GAMEFUSE_API FGFGameData
 {
 	GENERATED_BODY()
 
@@ -39,7 +39,7 @@ struct FGFGameData
 };
 
 USTRUCT(BlueprintType, Category = "GameFuse|UserData")
-struct FGFUserData
+struct GAMEFUSE_API FGFUserData
 {
 	GENERATED_BODY()
 
@@ -75,7 +75,7 @@ struct FGFUserData
 
 
 USTRUCT(BlueprintType, Category = "GameFuse|StoreItem")
-struct FGFStoreItem
+struct GAMEFUSE_API FGFStoreItem
 {
 	GENERATED_BODY()
 	FGFStoreItem() = default;
@@ -110,7 +110,7 @@ struct FGFStoreItem
 };
 
 USTRUCT(BlueprintType, Category = "GameFuse|LeaderboardItem")
-struct FGFLeaderboardEntry
+struct GAMEFUSE_API FGFLeaderboardEntry
 {
 	GENERATED_BODY()
 
@@ -136,7 +136,7 @@ struct FGFLeaderboardEntry
 };
 
 USTRUCT(BlueprintType, Category = "GameFuse|Leaderboard")
-struct FGFLeaderboard
+struct GAMEFUSE_API FGFLeaderboard
 {
 	GENERATED_BODY()
 
@@ -302,8 +302,35 @@ struct GAMEFUSE_API FGFGroupAttribute
 	}
 };
 
+USTRUCT(BlueprintType)
+struct GAMEFUSE_API FGFGroupConnection
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
+	int32 Id;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
+	EGFInviteRequestStatus Status;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
+	FGFUserData User;
+
+	FGFGroupConnection() :
+		Id(0), Status(EGFInviteRequestStatus::None)
+	{
+	}
+
+	bool operator==(const FGFGroupConnection& Other) const
+	{
+		return Id == Other.Id &&
+		Status == Other.Status &&
+		User == Other.User;
+	}
+};
+
 USTRUCT(BlueprintType, Category = "GameFuse|Groups")
-struct FGFGroup
+struct GAMEFUSE_API FGFGroup
 {
 	GENERATED_BODY()
 
@@ -343,41 +370,20 @@ struct FGFGroup
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	TArray<FGFGroupAttribute> Attributes;
 
+	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
+	TArray<FGFGroupConnection> JoinRequests;
+
+	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
+	TArray<FGFGroupConnection> Invites;
+
 	bool operator==(const FGFGroup& Other) const
 	{
 		return Id == Other.Id && Name == Other.Name;
 	}
 };
 
-USTRUCT(BlueprintType)
-struct GAMEFUSE_API FGFGroupConnection
-{
-	GENERATED_BODY()
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
-	int32 Id;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
-	EGFInviteRequestStatus Status;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
-	FGFUserData User;
-
-	FGFGroupConnection() :
-		Id(0), Status(EGFInviteRequestStatus::None)
-	{
-	}
-
-	bool operator==(const FGFGroupConnection& Other) const
-	{
-		return Id == Other.Id &&
-		Status == Other.Status &&
-		User == Other.User;
-	}
-};
-
 USTRUCT(BlueprintType, Category = "GameFuse| API")
-struct FGFAPIResponse
+struct GAMEFUSE_API FGFAPIResponse
 {
 	GENERATED_BODY()
 
@@ -406,7 +412,7 @@ struct FGFAPIResponse
 // Game Round Rankings User Data
 USTRUCT(BlueprintType, Category = "GameFuse|GameRound")
 
-struct FGFGameRoundRanking
+struct GAMEFUSE_API FGFGameRoundRanking
 {
 	GENERATED_BODY()
 
@@ -434,7 +440,7 @@ struct FGFGameRoundRanking
 // Main Game Round Structure
 USTRUCT(BlueprintType, Category = "GameFuse|GameRound")
 
-struct FGFGameRound
+struct GAMEFUSE_API FGFGameRound
 {
 	GENERATED_BODY()
 

--- a/Source/GameFuse/Public/Library/GameFuseStructLibrary.h
+++ b/Source/GameFuse/Public/Library/GameFuseStructLibrary.h
@@ -29,6 +29,9 @@ struct FGFGameData
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|GameData")
 	FString Description = "";
 
+	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|GameData")
+	FString ServerTime = "";
+
 	bool operator==(const FGFGameData& Other) const
 	{
 		return Id == Other.Id && Token == Other.Token && Name == Other.Name && Description == Other.Description;

--- a/Source/GameFuse/Public/Library/GameFuseStructLibrary.h
+++ b/Source/GameFuse/Public/Library/GameFuseStructLibrary.h
@@ -17,18 +17,23 @@ struct GAMEFUSE_API FGFGameData
 {
 	GENERATED_BODY()
 
+	/** Unique database ID of the game from GameFuse dashboard */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|GameData")
 	int32 Id = 0;
 
+	/** API token of the game found on your GameFuse.co dashboard */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|GameData")
 	FString Token = "";
 
+	/** Name of the game as configured in GameFuse dashboard */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|GameData")
 	FString Name = "";
 
+	/** Game description as configured in GameFuse dashboard */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|GameData")
 	FString Description = "";
 
+	/** Server timestamp when the game data was retrieved */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|GameData")
 	FString ServerTime = "";
 
@@ -43,27 +48,35 @@ struct GAMEFUSE_API FGFUserData
 {
 	GENERATED_BODY()
 
+	/** Unique database ID of the user from GameFuse */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|UserData")
 	int32 Id = 0;
 
+	/** Username of the user account */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|UserData")
 	FString Username = "";
 
+	/** Whether the user is currently signed in to GameFuse */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|UserData")
 	bool bSignedIn = false;
 
+	/** Total number of times the user has logged into the game */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|UserData")
 	int32 NumberOfLogins = 0;
 
+	/** Authentication token used for user session management and API requests */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|UserData")
 	FString AuthenticationToken = "";
 
+	/** User's current score that can be modified with add_score API calls */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|UserData")
 	int32 Score = 0;
 
+	/** User's current credits balance for in-game store purchases */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|UserData")
 	int32 Credits = 0;
 
+	/** Date and time of the user's last login in YYYY-MM-DD format */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|UserData")
 	FString LastLogin = "0000-00-00";
 
@@ -80,22 +93,27 @@ struct GAMEFUSE_API FGFStoreItem
 	GENERATED_BODY()
 	FGFStoreItem() = default;
 
+	/** Unique database ID of the store item */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|StoreItem")
 	int32 Id = 0;
 
+	/** Display name of the store item */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|StoreItem")
 	FString Name = "";
 
+	/** Category classification for organizing store items */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|StoreItem")
 	FString Category = "";
 
+	/** Detailed description of the store item and its effects */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|StoreItem")
 	FString Description = "";
 
+	/** Cost of the item in credits required for purchase */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|StoreItem")
 	int32 Cost = 0;
 
-
+	/** URL to the icon image for displaying the store item */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|StoreItem")
 	FString IconUrl = "";
 
@@ -116,21 +134,27 @@ struct GAMEFUSE_API FGFLeaderboardEntry
 
 	FGFLeaderboardEntry() = default;
 
+	/** Name of the leaderboard this entry belongs to */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Leaderboard")
 	FString LeaderboardName = "";
 
+	/** Username of the player for this leaderboard entry */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Leaderboard")
 	FString Username = "";
 
+	/** Score achieved by the player for this leaderboard entry */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Leaderboard")
 	int32 Score = 0;
 
+	/** GameFuse user ID of the player who achieved this score */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Leaderboard")
 	int32 GameUserId = 0;
 
+	/** Additional custom data associated with this leaderboard entry */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Leaderboard")
 	TMap<FString, FString> Metadata;
 
+	/** Date and time when this leaderboard entry was created */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Leaderboard")
 	FString DateTime = "";
 };
@@ -148,10 +172,11 @@ struct GAMEFUSE_API FGFLeaderboard
 		this->Entries = TArray<FGFLeaderboardEntry>();
 	}
 
-
+	/** Name identifier of the leaderboard */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Leaderboard")
 	FString Name = "";
 
+	/** Array of leaderboard entries sorted by rank */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Leaderboard")
 	TArray<FGFLeaderboardEntry> Entries;
 };
@@ -161,6 +186,7 @@ struct GAMEFUSE_API FGFAttributeList
 {
 	GENERATED_BODY()
 
+	/** Key-value pairs of custom user attributes for storing game-specific data */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Attributes")
 	TMap<FString, FString> Attributes;
 
@@ -192,7 +218,7 @@ struct GAMEFUSE_API FGFMessage
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Chat")
 	int32 Id = 0;
 
-	/** The message text */
+	/** The message text content */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Chat")
 	FString Text;
 
@@ -247,7 +273,7 @@ struct GAMEFUSE_API FGFChat
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Chat")
 	TArray<FGFMessage> Messages;
 
-	/** List of users in the chat */
+	/** List of users participating in the chat */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Chat")
 	TArray<FGFUserData> Participants;
 
@@ -273,11 +299,11 @@ struct GAMEFUSE_API FGFGroupAttribute
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Groups")
 	int32 Id = 0;
 
-	/** The key of the attribute */
+	/** The key name of the attribute for identification */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
 	FString Key;
 
-	/** The value of the attribute */
+	/** The value stored for this attribute */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
 	FString Value;
 
@@ -307,12 +333,15 @@ struct GAMEFUSE_API FGFGroupConnection
 {
 	GENERATED_BODY()
 
+	/** Unique identifier for this group connection */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
 	int32 Id;
 
+	/** Current status of the invite or join request */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
 	EGFInviteRequestStatus Status;
 
+	/** User data for the user in this group connection */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GameFuse|Groups")
 	FGFUserData User;
 
@@ -334,45 +363,59 @@ struct GAMEFUSE_API FGFGroup
 {
 	GENERATED_BODY()
 
+	/** Unique identifier of the group */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	int32 Id = 0;
 
+	/** Display name of the group */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	FString Name = "";
 
+	/** Type classification of the group (e.g., "clan", "guild", "team") */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	FString GroupType = "";
 
+	/** Maximum number of members allowed in this group */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	int32 MaxGroupSize = 0;
 
+	/** Whether users can automatically join this group without approval */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	bool bCanAutoJoin = false;
 
+	/** Whether the group only accepts members through invitations */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	bool bIsInviteOnly = false;
 
+	/** Whether this group appears in search results */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	bool bSearchable = true;
 
+	/** Whether only admins can create group attributes */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	bool bAdminsOnlyCanCreateAttributes = false;
 
+	/** Current number of members in the group */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	int32 MemberCount = 0;
 
+	/** Array of all group members */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	TArray<FGFUserData> Members;
 
+	/** Array of group administrators with elevated permissions */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	TArray<FGFUserData> Admins;
 
+	/** Custom attributes associated with this group */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	TArray<FGFGroupAttribute> Attributes;
 
+	/** Pending requests to join this group */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	TArray<FGFGroupConnection> JoinRequests;
 
+	/** Pending invitations sent by this group */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|Groups")
 	TArray<FGFGroupConnection> Invites;
 
@@ -387,16 +430,20 @@ struct GAMEFUSE_API FGFAPIResponse
 {
 	GENERATED_BODY()
 
+	/** Whether the API request was successful */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|API")
 	bool bSuccess = false;
 
+	/** Raw response string from the GameFuse API */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|API")
 	FString ResponseStr = "";
 
+	/** Unique identifier for tracking this specific API request */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|API")
 	FGuid RequestId;
 	FGFAPIResponse() = default;
 
+	/** HTTP response code from the API request (200, 401, 500, etc.) */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|API")
 	int ResponseCode = 0;
 
@@ -416,18 +463,23 @@ struct GAMEFUSE_API FGFGameRoundRanking
 {
 	GENERATED_BODY()
 
+	/** Final placement/rank of the user in the game round (1st, 2nd, 3rd, etc.) */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	int32 Place = 0;
 
+	/** Score achieved by the user in this game round */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	int32 Score = 0;
 
+	/** When the user started participating in this game round */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	FDateTime StartTime;
 
+	/** When the user finished participating in this game round */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	FDateTime EndTime;
 
+	/** User data for the player in this ranking */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	FGFUserData User;
 
@@ -444,36 +496,50 @@ struct GAMEFUSE_API FGFGameRound
 {
 	GENERATED_BODY()
 
+	/**
+	 * The ID of the game round. Will be set by the server when creating a new round.
+	 * For updates, this should match the existing round's ID.
+	 */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	int32 Id = 0;
 
+	/** The GameFuse user ID of the player who participated in this round */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	int32 GameUserId = 0;
 
+	/** When this game round started */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	FDateTime StartTime;
 
+	/** When this game round ended */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	FDateTime EndTime;
 
+	/** Final score achieved in this game round */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	int32 Score = 0;
 
+	/** Final placement/rank in this game round (-1 if not set) */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	int32 Place = -1;
 
+	/** Type or category of game (e.g., "deathmatch", "racing", "puzzle") */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	FString GameType = "";
 
+	/** ID linking to a multiplayer game round if this is part of a multiplayer session */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	int32 MultiplayerGameRoundId = -1;
 
+	/** Custom key-value data associated with this game round */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	TMap<FString, FString> Metadata;
 
+	/** Whether this is a multiplayer game round involving multiple players */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	bool bMultiplayer = false;
 
+	/** Rankings of all players if this is a multiplayer round */
 	UPROPERTY(BlueprintReadWrite, Category = "GameFuse|GameRound")
 	TArray<FGFGameRoundRanking> Rankings;
 
@@ -506,15 +572,19 @@ struct GAMEFUSE_API FGFFriendRequest
 {
 	GENERATED_BODY()
 
+	/** Unique identifier for this friendship/friend request */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Friends")
 	int32 FriendshipId = 0;
 
+	/** User data for the other user in this friend relationship */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Friends")
 	FGFUserData OtherUser;
 
+	/** Current status of the friend request (pending, accepted, etc.) */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Friends")
 	EGFInviteRequestStatus Status = EGFInviteRequestStatus::None;
 
+	/** When this friend request was created */
 	UPROPERTY(BlueprintReadOnly, Category = "GameFuse|Friends")
 	FDateTime RequestCreatedAt;
 

--- a/Source/GameFuse/Public/Library/GameFuseUtilities.h
+++ b/Source/GameFuse/Public/Library/GameFuseUtilities.h
@@ -433,6 +433,13 @@ public:
 	 */
 	static bool ConvertJsonToGameVariables(TMap<FString, FString>& OutVariables, const FString& JsonString);
 
+	/**
+	 * Converts a JSON string into ServerTime
+	 * @param OutServerTime String to store the converted server time
+	 * @param JsonString The JSON string to convert
+	 * @return true if successful
+	 */
+	static bool ConvertJsonToServerTime(FString& OutServerTime, const FString& JsonString);
 
 #pragma endregion
 };

--- a/Source/GameFuse/Public/Library/GameFuseUtilities.h
+++ b/Source/GameFuse/Public/Library/GameFuseUtilities.h
@@ -269,6 +269,14 @@ public:
 	static bool ConvertJsonToGroupConnection(FGFGroupConnection& InConnection, const FString& JsonString);
 
 	/**
+	 * Converts a JSON array to an Array of GroupConnections
+	 * @param InConnections Array to store converted data
+	 * @param JsonArray Json Values to Parse
+	 * @return true if successful
+	 */
+	static bool ConvertJsonArrayToGroupConnections(TArray<FGFGroupConnection>& InConnections, const TArray<TSharedPtr<FJsonValue>>* JsonArray);
+
+	/**
 	 * Converts a JSON array into an array of GroupAttributes
 	 * @param InAttributes Array to store converted data
 	 * @param JsonArray The JSON array to convert

--- a/Source/GameFuse/Public/Subsystems/GameFuseChat.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseChat.h
@@ -26,13 +26,13 @@ public:
 
 	// Blueprint Callable Functions
 	/**
-	 * Creates a new chat with participants (Blueprint version)
-	 * @param ParticipantIds Array of user IDs to include in the chat
+	 * Creates a new chat with participants. The new chat is cached for quick access. (Blueprint version)
+	 * @param Usernames Array of usernames to include in the chat
 	 * @param InitialMessage The first message to send in the chat
 	 * @param Callback Blueprint callback executed when the request completes
 	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Create Chat", Category = "GameFuse|Chat")
-	void BP_CreateChat(const TArray<FString>& ParticipantIds, const FString& InitialMessage, const FBP_GFApiCallback& Callback);
+	void BP_CreateChat(const TArray<FString>& Usernames, const FString& InitialMessage, const FBP_GFApiCallback& Callback);
 
 	/**
 	 * Sends a message to a chat (Blueprint version)
@@ -70,13 +70,13 @@ public:
 
 	// C++ callable functions with typed callbacks
 	/**
-	 * Creates a new chat with participants
-	 * @param ParticipantIds Array of user IDs to include in the chat
+	 * Creates a new chat with participants. The new chat is cached for quick access.
+	 * @param Usernames Array of usernames to include in the chat
 	 * @param InitialMessage The first message to send in the chat
 	 * @param TypedCallback Callback executed when the request completes
 	 * @return Request ID for tracking
 	 */
-	FGuid CreateChat(const TArray<FString>& ParticipantIds, const FString& InitialMessage, FGFChatCallback TypedCallback);
+	FGuid CreateChat(const TArray<FString>& Usernames, const FString& InitialMessage, FGFChatCallback TypedCallback);
 	
 	/**
 	 * Sends a message to a chat
@@ -118,9 +118,9 @@ public:
 	 * @return The last fetched list of all chats
 	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Chat")
-	const TArray<FGFChat>& GetAllChats() const
+	const TArray<FGFChat>& GetCachedChats() const
 	{
-		return AllChats;
+		return CachedChats;
 	}
 
 	/**
@@ -147,7 +147,7 @@ public:
 	 */
 	void ClearChatData()
 	{
-		AllChats.Empty();
+		CachedChats.Empty();
 		ChatMessages.Empty();
 	}
 
@@ -157,7 +157,7 @@ private:
 	TObjectPtr<UChatAPIHandler> RequestHandler;
 
 	// Cached chat data
-	TArray<FGFChat> AllChats;
+	TArray<FGFChat> CachedChats;
 	TArray<FGFMessage> ChatMessages;
 
 	// Internal response handlers

--- a/Source/GameFuse/Public/Subsystems/GameFuseChat.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseChat.h
@@ -25,47 +25,126 @@ public:
 	virtual void Deinitialize() override;
 
 	// Blueprint Callable Functions
+	/**
+	 * Creates a new chat with participants (Blueprint version)
+	 * @param ParticipantIds Array of user IDs to include in the chat
+	 * @param InitialMessage The first message to send in the chat
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Create Chat", Category = "GameFuse|Chat")
 	void BP_CreateChat(const TArray<FString>& ParticipantIds, const FString& InitialMessage, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Sends a message to a chat (Blueprint version)
+	 * @param ChatId The ID of the chat to send the message to
+	 * @param Message The message content to send
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Send Message", Category = "GameFuse|Chat")
 	void BP_SendMessage(int32 ChatId, const FString& Message, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Marks a message as read (Blueprint version)
+	 * @param MessageId The ID of the message to mark as read
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Mark Message As Read", Category = "GameFuse|Chat")
 	void BP_MarkMessageAsRead(int32 MessageId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches all chats for the current user (Blueprint version)
+	 * @param Page Page number for pagination
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch All Chats", Category = "GameFuse|Chat", meta = (Page = 1))
 	void BP_FetchAllChats(int32 Page, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches messages for a specific chat (Blueprint version)
+	 * @param ChatId The ID of the chat to fetch messages from
+	 * @param Page Page number for pagination
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Messages", Category = "GameFuse|Chat", meta = (Page = 1))
 	void BP_FetchMessages(int32 ChatId, int32 Page, const FBP_GFApiCallback& Callback);
 
 	// C++ callable functions with typed callbacks
+	/**
+	 * Creates a new chat with participants
+	 * @param ParticipantIds Array of user IDs to include in the chat
+	 * @param InitialMessage The first message to send in the chat
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid CreateChat(const TArray<FString>& ParticipantIds, const FString& InitialMessage, FGFChatCallback TypedCallback);
+	
+	/**
+	 * Sends a message to a chat
+	 * @param ChatId The ID of the chat to send the message to
+	 * @param Message The message content to send
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid SendMessage(int32 ChatId, const FString& Message, FGFMessageCallback TypedCallback);
+	
+	/**
+	 * Marks a message as read
+	 * @param MessageId The ID of the message to mark as read
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid MarkMessageAsRead(int32 MessageId, FGFSuccessCallback TypedCallback);
+	
+	/**
+	 * Fetches all chats for the current user
+	 * @param Page Page number for pagination
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchAllChats(int32 Page, FGFChatListCallback TypedCallback);
+	
+	/**
+	 * Fetches messages for a specific chat
+	 * @param ChatId The ID of the chat to fetch messages from
+	 * @param Page Page number for pagination
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchMessages(int32 ChatId, int32 Page, FGFMessageListCallback TypedCallback);
 
 	// Getters for cached data
+	/**
+	 * Gets the cached list of all chats
+	 * @return The last fetched list of all chats
+	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Chat")
 	const TArray<FGFChat>& GetAllChats() const
 	{
 		return AllChats;
 	}
 
+	/**
+	 * Gets the cached list of chat messages
+	 * @return The last fetched list of chat messages
+	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Chat")
 	const TArray<FGFMessage>& GetChatMessages() const
 	{
 		return ChatMessages;
 	}
 
+	/**
+	 * Gets the request handler for direct API access
+	 * @return Pointer to the chat API handler
+	 */
 	TObjectPtr<UChatAPIHandler> GetRequestHandler() const
 	{
 		return RequestHandler;
 	}
 
-	// Clear cached chat data
+	/**
+	 * Clears all cached chat data
+	 */
 	void ClearChatData()
 	{
 		AllChats.Empty();
@@ -82,10 +161,34 @@ private:
 	TArray<FGFMessage> ChatMessages;
 
 	// Internal response handlers
+	/**
+	 * Handles responses for single chat operations
+	 * @param Response The API response to process
+	 */
 	void HandleChatResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for chat list operations
+	 * @param Response The API response to process
+	 */
 	void HandleChatListResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for message list operations
+	 * @param Response The API response to process
+	 */
 	void HandleMessageListResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for single message operations
+	 * @param Response The API response to process
+	 */
 	void HandleMessageResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for action operations (like mark as read)
+	 * @param Response The API response to process
+	 */
 	void HandleActionResponse(FGFAPIResponse Response);
 
 	// User callbacks storage

--- a/Source/GameFuse/Public/Subsystems/GameFuseFriends.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseFriends.h
@@ -44,8 +44,11 @@ public:
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Friendship Data", Category = "GameFuse|Friends")
 	void BP_FetchFriendshipData(const FBP_GFApiCallback& Callback);
 
-	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Friends List", Category = "GameFuse|Friends")
-	void BP_FetchFriendsList(const FBP_GFApiCallback& Callback);
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Friends List", Category = "GameFuse|Friends")
+	void BP_FetchMyFriendsList(const FBP_GFApiCallback& Callback);
+
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Friends List", Category = "GameFuse|Friends")
+	void BP_FetchUserFriendsList(int32 UserId, const FBP_GFApiCallback& Callback);
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Outgoing Friend Requests", Category = "GameFuse|Friends")
 	void BP_FetchOutgoingFriendRequests(const FBP_GFApiCallback& Callback);
@@ -62,8 +65,10 @@ public:
 
 	/** Retrieve the list of friends, outgoing, and incoming friendship requests for the current user. */
 	FGuid FetchFriendshipData(FGFFriendsCallback TypedCallback);
-	/** Fetch a list of all friends */
-	FGuid FetchFriendsList(FGFFriendsCallback TypedCallback);
+	/** Fetch a list of all your friends */
+	FGuid FetchMyFriendsList(FGFFriendsCallback TypedCallback);
+	/** Fetch a list of all friends for a specific user */
+	FGuid FetchUserFriendsList(int32 UserId, FGFFriendsCallback TypedCallback);
 	FGuid FetchOutgoingFriendRequests(FGFFriendRequestsCallback TypedCallback);
 	FGuid FetchIncomingFriendRequests(FGFFriendRequestsCallback TypedCallback);
 
@@ -104,6 +109,7 @@ private:
 	// Internal response handlers
 	void HandleFriendshipDataResponse(FGFAPIResponse Response);
 	void HandleFriendsListResponse(FGFAPIResponse Response);
+	void HandleUserFriendsListResponse(FGFAPIResponse Response);
 	void HandleOutgoingRequestsResponse(FGFAPIResponse Response);
 	void HandleIncomingRequestsResponse(FGFAPIResponse Response);
 	void HandleFriendRequestResponse(FGFAPIResponse Response);

--- a/Source/GameFuse/Public/Subsystems/GameFuseFriends.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseFriends.h
@@ -26,71 +26,180 @@ public:
 	virtual void Deinitialize() override;
 
 	//> Blueprint Callable Functions
+	/**
+	 * Sends a friend request to a user by username (Blueprint version)
+	 * @param Username The username to send the request to
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Send Friend Request", Category = "GameFuse|Friends")
 	void BP_SendFriendRequest(const FString& Username, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Accepts a friend request (Blueprint version)
+	 * @param FriendshipId The ID of the friendship request to accept
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Accept Friend Request", Category = "GameFuse|Friends")
 	void BP_AcceptFriendRequest(int32 FriendshipId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Declines a friend request (Blueprint version)
+	 * @param FriendshipId The ID of the friendship request to decline
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Decline Friend Request", Category = "GameFuse|Friends")
 	void BP_DeclineFriendRequest(int32 FriendshipId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Cancels a sent friend request (Blueprint version)
+	 * @param FriendshipId The ID of the friendship request to cancel
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Cancel Friend Request", Category = "GameFuse|Friends")
 	void BP_CancelFriendRequest(int32 FriendshipId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Removes a user from friends list (Blueprint version)
+	 * @param UserId The ID of the user to unfriend
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Unfriend Player", Category = "GameFuse|Friends")
 	void BP_UnfriendPlayer(int32 UserId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Retrieves the list of friends, outgoing, and incoming friendship requests for the current user (Blueprint version)
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Friendship Data", Category = "GameFuse|Friends")
 	void BP_FetchFriendshipData(const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches a list of all your friends (Blueprint version)
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Friends List", Category = "GameFuse|Friends")
 	void BP_FetchMyFriendsList(const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches a list of all friends for a specific user (Blueprint version)
+	 * @param UserId The ID of the user to fetch friends for
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Friends List", Category = "GameFuse|Friends")
 	void BP_FetchUserFriendsList(int32 UserId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches outgoing friend requests for the current user (Blueprint version)
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Outgoing Friend Requests", Category = "GameFuse|Friends")
 	void BP_FetchOutgoingFriendRequests(const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches incoming friend requests for the current user (Blueprint version)
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Incoming Friend Requests", Category = "GameFuse|Friends")
 	void BP_FetchIncomingFriendRequests(const FBP_GFApiCallback& Callback);
 
 	// C++ callable functions with typed callbacks
+	/**
+	 * Sends a friend request to a user by username
+	 * @param Username The username to send the request to
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid SendFriendRequest(const FString& Username, FGFFriendRequestCallback TypedCallback);
+	
+	/**
+	 * Accepts a friend request
+	 * @param FriendshipId The ID of the friendship request to accept
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid AcceptFriendRequest(const int32 FriendshipId, FGFFriendActionCallback TypedCallback);
+	
+	/**
+	 * Declines a friend request
+	 * @param FriendshipId The ID of the friendship request to decline
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid DeclineFriendRequest(const int32 FriendshipId, FGFFriendActionCallback TypedCallback);
+	
+	/**
+	 * Cancels a sent friend request
+	 * @param FriendshipId The ID of the friendship request to cancel
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid CancelFriendRequest(const int32 FriendshipId, FGFFriendActionCallback TypedCallback);
+	
+	/**
+	 * Removes a user from friends list
+	 * @param UserId The ID of the user to unfriend
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid UnfriendPlayer(const int32 UserId, FGFFriendActionCallback TypedCallback);
 
 	/** Retrieve the list of friends, outgoing, and incoming friendship requests for the current user. */
 	FGuid FetchFriendshipData(FGFFriendsCallback TypedCallback);
+	
 	/** Fetch a list of all your friends */
 	FGuid FetchMyFriendsList(FGFFriendsCallback TypedCallback);
+	
 	/** Fetch a list of all friends for a specific user */
 	FGuid FetchUserFriendsList(int32 UserId, FGFFriendsCallback TypedCallback);
+	
+	/**
+	 * Fetches outgoing friend requests for the current user
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchOutgoingFriendRequests(FGFFriendRequestsCallback TypedCallback);
+	
+	/**
+	 * Fetches incoming friend requests for the current user
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchIncomingFriendRequests(FGFFriendRequestsCallback TypedCallback);
 
-	// Getters for cached data
+	/**
+	 * Gets the cached list of friends
+	 * @return The last fetched friends list
+	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Friends")
 	const TArray<FGFUserData>& GetFriendsList() const
 	{
 		return FriendsList;
 	}
 
+	/**
+	 * Gets the cached list of outgoing friend requests
+	 * @return Last fetched list of outgoing friend requests
+	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Friends")
 	const TArray<FGFFriendRequest>& GetOutgoingRequests() const
 	{
 		return OutgoingRequests;
 	}
 
+	/**
+	 * Gets the cached list of incoming friend requests
+	 * @return Last fetched list of incoming friend requests
+	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Friends")
 	const TArray<FGFFriendRequest>& GetIncomingRequests() const
 	{
 		return IncomingRequests;
 	}
 
+	/**
+	 * Gets the request handler for direct API access
+	 * @return Pointer to the friends API handler
+	 */
 	TObjectPtr<UFriendsAPIHandler> GetRequestHandler() const
 	{
 		return RequestHandler;
@@ -107,12 +216,46 @@ private:
 	TArray<FGFFriendRequest> IncomingRequests;
 
 	// Internal response handlers
+	/**
+	 * Handles responses for friendship data operations
+	 * @param Response The API response to process
+	 */
 	void HandleFriendshipDataResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for friends list operations
+	 * @param Response The API response to process
+	 */
 	void HandleFriendsListResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for specific user friends list operations
+	 * @param Response The API response to process
+	 */
 	void HandleUserFriendsListResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for outgoing friend requests
+	 * @param Response The API response to process
+	 */
 	void HandleOutgoingRequestsResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for incoming friend requests
+	 * @param Response The API response to process
+	 */
 	void HandleIncomingRequestsResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for friend request operations
+	 * @param Response The API response to process
+	 */
 	void HandleFriendRequestResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for friend action operations
+	 * @param Response The API response to process
+	 */
 	void HandleFriendActionResponse(FGFAPIResponse Response);
 
 	// User callbacks storage

--- a/Source/GameFuse/Public/Subsystems/GameFuseGroups.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseGroups.h
@@ -27,60 +27,237 @@ public:
 	virtual void Deinitialize() override;
 
 	// C++ API
+	/**
+	 * Creates a new group
+	 * @param Group The group data to create
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid CreateGroup(const FGFGroup& Group, FGFGroupCallback TypedCallback);
+	
+	/**
+	 * Fetches a specific group by ID
+	 * @param GroupId The ID of the group to fetch
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchGroup(const int32 GroupId, FGFGroupCallback TypedCallback);
+	
+	/**
+	 * Fetches all available groups
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchAllGroups(FGFGroupListCallback TypedCallback);
+	
+	/**
+	 * Requests to join a group
+	 * @param GroupId The ID of the group to join
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid RequestToJoinGroup(int32 GroupId, FGFGroupConnectionCallback TypedCallback);
+	
+	/**
+	 * Deletes a group (admin only)
+	 * @param GroupId The ID of the group to delete
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid DeleteGroup(const int32 GroupId, FGFGroupActionCallback TypedCallback);
+	
+	/**
+	 * Joins a group directly (if allowed)
+	 * @param GroupId The ID of the group to join
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid JoinGroup(const int32 GroupId, FGFGroupActionCallback TypedCallback);
+	
+	/**
+	 * Leaves a group
+	 * @param GroupId The ID of the group to leave
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid LeaveGroup(const int32 GroupId, FGFGroupActionCallback TypedCallback);
-	FGuid FetchUserGroups(FGFGroupListCallback TypedCallback);
+	
+	/**
+	 * Fetches groups for the current user
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
+	FGuid FetchMyGroups(FGFGroupListCallback TypedCallback);
+	
+	/**
+	 * Searches for groups by query, filling the Fetched groups data
+	 * @param Query The search query
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid SearchGroups(const FString& Query, FGFGroupListCallback TypedCallback);
+	
+	/**
+	 * Adds a user as admin to a group
+	 * @param GroupId The ID of the group
+	 * @param UserId The ID of the user to make admin
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid AddAdmin(const int32 GroupId, const int32 UserId, FGFGroupActionCallback TypedCallback);
+	
+	/**
+	 * Removes admin status from a user in a group
+	 * @param GroupId The ID of the group
+	 * @param UserId The ID of the user to remove admin status from
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid RemoveAdmin(const int32 GroupId, const int32 UserId, FGFGroupActionCallback TypedCallback);
+	
+	/**
+	 * Adds an attribute to a group
+	 * @param GroupId The ID of the group
+	 * @param Attribute The attribute to add
+	 * @param bOthersCanEdit Whether other users can edit this attribute
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOthersCanEdit, FGFGroupAttributeCallback TypedCallback);
+	
+	/**
+	 * Updates a group attribute
+	 * @param GroupId The ID of the group
+	 * @param Attribute The updated attribute data
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid UpdateGroupAttribute(int32 GroupId, const FGFGroupAttribute& Attribute, FGFGroupActionCallback TypedCallback);
 	// FGuid DeleteAttribute(const int32 GroupId, const int32 AttributeId, FGFGroupActionCallback TypedCallback);
+	
+	/**
+	 * Fetches attributes for a group
+	 * @param GroupId The ID of the group
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchGroupAttributes(const int32 GroupId, FGFGroupAttributeCallback TypedCallback);
+	
+	/**
+	 * Responds to a group join request (accept/decline)
+	 * @param ConnectionId The ID of the connection request
+	 * @param UserId The ID of the user making the request
+	 * @param Status The response status (accept/decline)
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid RespondToGroupJoinRequest(const int32 ConnectionId, const int32 UserId, EGFInviteRequestStatus Status, FGFGroupActionCallback TypedCallback);
 
 	// Blueprint API
+	/**
+	 * Creates a new group (Blueprint version)
+	 * @param Group The group data to create
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Create Group", Category = "GameFuse|Groups")
 	void BP_CreateGroup(const FGFGroup& Group, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches a specific group by ID (Blueprint version)
+	 * @param GroupId The ID of the group to fetch
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Group", Category = "GameFuse|Groups")
 	void BP_FetchGroup(const int32 GroupId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches all available groups (Blueprint version)
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch All Groups", Category = "GameFuse|Groups")
 	void BP_FetchAllGroups(const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Requests to join a group (Blueprint version)
+	 * @param GroupId The ID of the group to join
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Request To Join Group", Category = "GameFuse|Groups")
 	void BP_RequestToJoinGroup(int32 GroupId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Deletes a group (admin only) (Blueprint version)
+	 * @param GroupId The ID of the group to delete
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Delete Group", Category = "GameFuse|Groups")
 	void BP_DeleteGroup(const int32 GroupId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Joins a group directly (if allowed) (Blueprint version)
+	 * @param GroupId The ID of the group to join
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Join Group", Category = "GameFuse|Groups")
 	void BP_JoinGroup(const int32 GroupId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Leaves a group (Blueprint version)
+	 * @param GroupId The ID of the group to leave
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Leave Group", Category = "GameFuse|Groups")
 	void BP_LeaveGroup(const int32 GroupId, const FBP_GFApiCallback& Callback);
 
-	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Groups", Category = "GameFuse|Groups")
-	void BP_FetchUserGroups(const FBP_GFApiCallback& Callback);
+	/**
+	 * Fetches groups for the current user (Blueprint version)
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Groups", Category = "GameFuse|Groups")
+	void BP_FetchMyGroups(const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Searches for groups by query (Blueprint version)
+	 * @param Query The search query
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Search Groups", Category = "GameFuse|Groups")
 	void BP_SearchGroups(const FString& Query, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Adds a user as admin to a group (Blueprint version)
+	 * @param GroupId The ID of the group
+	 * @param UserId The ID of the user to make admin
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Add Admin", Category = "GameFuse|Groups")
 	void BP_AddAdmin(const int32 GroupId, const int32 UserId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Removes admin status from a user in a group (Blueprint version)
+	 * @param GroupId The ID of the group
+	 * @param UserId The ID of the user to remove admin status from
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Remove Admin", Category = "GameFuse|Groups")
 	void BP_RemoveAdmin(const int32 GroupId, const int32 UserId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Adds an attribute to a group (Blueprint version)
+	 * @param GroupId The ID of the group
+	 * @param Attribute The attribute to add
+	 * @param bOthersCanEdit Whether other users can edit this attribute
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Add Attribute", Category = "GameFuse|Groups")
 	void BP_AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOthersCanEdit, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Updates a group attribute (Blueprint version)
+	 * @param GroupId The ID of the group
+	 * @param Attribute The updated attribute data
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Update Group Attribute", Category = "GameFuse|Groups")
 	void BP_UpdateGroupAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, const FBP_GFApiCallback& Callback);
 
@@ -88,30 +265,50 @@ public:
 	// void BP_DeleteAttribute(const int32 GroupId, const int32 AttributeId, const FBP_GFApiCallback& Callback);
 
 	/**
-	 * Fetches attributes for a group
+	 * Fetches attributes for a group (Blueprint version)
 	 * @param GroupId ID of group
 	 * @param Callback Callback to execute when the request is complete
 	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Group Attributes", Category = "GameFuse|Groups")
 	void BP_FetchGroupAttributes(const int32 GroupId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Accepts a group join request (Blueprint version)
+	 * @param ConnectionId The ID of the connection request
+	 * @param UserId The ID of the user making the request
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Accept Group Join Request", Category = "GameFuse|Groups")
 	void BP_AcceptGroupJoinRequest(const int32 ConnectionId, const int32 UserId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Declines a group join request (Blueprint version)
+	 * @param ConnectionId The ID of the connection request
+	 * @param UserId The ID of the user making the request
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Decline Group Join Request", Category = "GameFuse|Groups")
 	void BP_DeclineGroupJoinRequest(const int32 ConnectionId, const int32 UserId, const FBP_GFApiCallback& Callback);
 
 	// Getters for cached data
+	/**
+	 * Gets the cached list of user groups
+	 * @return The last fetched user groups
+	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Groups")
-	const TArray<FGFGroup>& GetUserGroups() const
+	const TArray<FGFGroup>& GetMyGroups() const
 	{
-		return UserGroups;
+		return MyGroups;
 	}
 
+	/**
+	 * Gets the cached list of fetched groups, usually filled by Search Group
+	 * @return The last fetched list of groups
+	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Groups")
-	const TArray<FGFGroup>& GetAllGroups() const
+	const TArray<FGFGroup>& GetFetchedGroups() const
 	{
-		return AllGroups;
+		return FetchedGroups;
 	}
 
 	/**
@@ -123,6 +320,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Groups")
 	bool GetGroupById(const int32 GroupId, FGFGroup& OutGroup) const;
 
+	/**
+	 * Gets the request handler for direct API access
+	 * @return Pointer to the groups API handler
+	 */
 	TObjectPtr<UGroupsAPIHandler> GetRequestHandler() const
 	{
 		return RequestHandler;
@@ -134,15 +335,45 @@ private:
 	TObjectPtr<UGroupsAPIHandler> RequestHandler;
 
 	// Cached group data
-	TArray<FGFGroup> UserGroups;
-	TArray<FGFGroup> AllGroups;
+	TArray<FGFGroup> MyGroups;
+	TArray<FGFGroup> FetchedGroups;
 
 	// Internal response handlers
+	/**
+	 * Handles responses for single group operations
+	 * @param Response The API response to process
+	 */
 	void HandleGroupResponse(const FGFAPIResponse& Response);
+	
+	/**
+	 * Handles responses for group list operations
+	 * @param Response The API response to process
+	 * @param bIsUserGroups Whether this is for user groups or all groups
+	 */
 	void HandleGroupListResponse(const FGFAPIResponse& Response, bool bIsUserGroups = false);
+	
+	/**
+	 * Handles responses for group connection operations
+	 * @param Response The API response to process
+	 */
 	void HandleGroupConnectionResponse(const FGFAPIResponse& Response);
+	
+	/**
+	 * Handles responses for group action operations
+	 * @param Response The API response to process
+	 */
 	void HandleGroupActionResponse(const FGFAPIResponse& Response);
+	
+	/**
+	 * Handles responses for group attribute operations
+	 * @param Response The API response to process
+	 */
 	void HandleGroupAttributeResponse(const FGFAPIResponse& Response);
+	
+	/**
+	 * Handles responses for fetching group attributes
+	 * @param Response The API response to process
+	 */
 	void HandleFetchAttributesResponse(FGFAPIResponse Response);
 
 	// User callbacks storage

--- a/Source/GameFuse/Public/Subsystems/GameFuseGroups.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseGroups.h
@@ -310,7 +310,7 @@ public:
 
 	// Getters for cached data
 	/**
-	 * Gets the cached list of user groups
+	 * Gets the cached list of user groups, use FetchMyGroups to fill this
 	 * @return The last fetched user groups
 	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Groups")
@@ -320,7 +320,7 @@ public:
 	}
 
 	/**
-	 * Gets the cached list of fetched groups, usually filled by Search Group
+	 * Gets the cached list of fetched groups, usually filled by Search Groups or Fetch All Groups
 	 * @return The last fetched list of groups
 	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Groups")
@@ -354,6 +354,10 @@ private:
 
 	// Cached group data
 	TArray<FGFGroup> MyGroups;
+
+	/**
+	 * Cached groups fetched from the API, usually filled by SearchGroups or FetchAllGroups
+	 */
 	TArray<FGFGroup> FetchedGroups;
 
 	// Internal response handlers

--- a/Source/GameFuse/Public/Subsystems/GameFuseGroups.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseGroups.h
@@ -38,7 +38,7 @@ public:
 	FGuid SearchGroups(const FString& Query, FGFGroupListCallback TypedCallback);
 	FGuid AddAdmin(const int32 GroupId, const int32 UserId, FGFGroupActionCallback TypedCallback);
 	FGuid RemoveAdmin(const int32 GroupId, const int32 UserId, FGFGroupActionCallback TypedCallback);
-	FGuid AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOnlyCreatorCanEdit, FGFGroupAttributeCallback TypedCallback);
+	FGuid AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOthersCanEdit, FGFGroupAttributeCallback TypedCallback);
 	FGuid UpdateGroupAttribute(int32 GroupId, const FGFGroupAttribute& Attribute, FGFGroupActionCallback TypedCallback);
 	// FGuid DeleteAttribute(const int32 GroupId, const int32 AttributeId, FGFGroupActionCallback TypedCallback);
 	FGuid FetchGroupAttributes(const int32 GroupId, FGFGroupAttributeCallback TypedCallback);
@@ -79,7 +79,7 @@ public:
 	void BP_RemoveAdmin(const int32 GroupId, const int32 UserId, const FBP_GFApiCallback& Callback);
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Add Attribute", Category = "GameFuse|Groups")
-	void BP_AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOnlyCreatorCanEdit, const FBP_GFApiCallback& Callback);
+	void BP_AddAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, bool bOthersCanEdit, const FBP_GFApiCallback& Callback);
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Update Group Attribute", Category = "GameFuse|Groups")
 	void BP_UpdateGroupAttribute(const int32 GroupId, const FGFGroupAttribute& Attribute, const FBP_GFApiCallback& Callback);

--- a/Source/GameFuse/Public/Subsystems/GameFuseGroups.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseGroups.h
@@ -59,6 +59,15 @@ public:
 	FGuid RequestToJoinGroup(int32 GroupId, FGFGroupConnectionCallback TypedCallback);
 	
 	/**
+	 * Invites a user to join a group
+	 * @param GroupId The ID of the group to invite the user to
+	 * @param UserIdToInvite The ID of the user to invite
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
+	FGuid InviteGroupMember(int32 GroupId, int32 UserIdToInvite, FGFGroupConnectionCallback TypedCallback);
+	
+	/**
 	 * Deletes a group (admin only)
 	 * @param GroupId The ID of the group to delete
 	 * @param TypedCallback Callback executed when the request completes
@@ -184,6 +193,15 @@ public:
 	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Request To Join Group", Category = "GameFuse|Groups")
 	void BP_RequestToJoinGroup(int32 GroupId, const FBP_GFApiCallback& Callback);
+
+	/**
+	 * Invites a user to join a group (Blueprint version)
+	 * @param GroupId The ID of the group to invite the user to
+	 * @param UserIdToInvite The ID of the user to invite
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
+	UFUNCTION(BlueprintCallable, DisplayName = "Invite Group Member", Category = "GameFuse|Groups")
+	void BP_InviteGroupMember(int32 GroupId, int32 UserIdToInvite, const FBP_GFApiCallback& Callback);
 
 	/**
 	 * Deletes a group (admin only) (Blueprint version)

--- a/Source/GameFuse/Public/Subsystems/GameFuseManager.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseManager.h
@@ -25,7 +25,9 @@
 
 #include "GameFuseManager.generated.h"
 
-
+/**
+ * Core subsystem for connecting to the GameFuse server
+ */
 UCLASS()
 class GAMEFUSE_API UGameFuseManager : public UGameInstanceSubsystem
 {
@@ -176,14 +178,16 @@ public:
 	 * Get the current server time from GameFuse in UTC
 	 * @param Callback Blueprint Dynamic Delegate
 	 */
-	UFUNCTION(BlueprintCallable, DisplayName = "Get Server Time", Category = "GameFuse | Manager")
-	void BP_GetServerTime(const FBP_GFApiCallback& Callback);
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Server Time", Category = "GameFuse | Manager")
+	void BP_FetchServerTime(const FBP_GFApiCallback& Callback);
 
 	/**
-	 * Get the current server time from GameFuse in UTC
+	 * Get the current server time from GameFuse in UTC.
+	 *
+	 * Data is stored in GameData
 	 * @param Callback CPP Multicast Delegate
 	 */
-	FGuid GetServerTime(FGFApiCallback Callback);
+	FGuid FetchServerTime(FGFApiCallback Callback);
 
 private:
 

--- a/Source/GameFuse/Public/Subsystems/GameFuseManager.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseManager.h
@@ -171,6 +171,20 @@ public:
 	 */
 	FGuid FetchStoreItems(FGFApiCallback Callback);
 
+	/**
+	 * DO NOT USE FROM C++
+	 * Get the current server time from GameFuse in UTC
+	 * @param Callback Blueprint Dynamic Delegate
+	 */
+	UFUNCTION(BlueprintCallable, DisplayName = "Get Server Time", Category = "GameFuse | Manager")
+	void BP_GetServerTime(const FBP_GFApiCallback& Callback);
+
+	/**
+	 * Get the current server time from GameFuse in UTC
+	 * @param Callback CPP Multicast Delegate
+	 */
+	FGuid GetServerTime(FGFApiCallback Callback);
+
 private:
 
 	FGFGameData GameData;
@@ -228,4 +242,10 @@ private:
 	 * @param Response The API response
 	 */
 	void HandleForgotPasswordResponse(FGFAPIResponse Response);
+
+	/**
+	 * @brief Handles the response for GetServerTime requests
+	 * @param Response The API response
+	 */
+	void HandleGetServerTimeResponse(FGFAPIResponse Response);
 };

--- a/Source/GameFuse/Public/Subsystems/GameFuseRounds.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseRounds.h
@@ -32,8 +32,11 @@ public:
 	UFUNCTION(BlueprintCallable, DisplayName = "Update Game Round", Category = "GameFuse|Rounds")
 	void BP_UpdateGameRound(const int32 RoundId, const FGFGameRound& GameRound, const FBP_GFApiCallback& Callback);
 
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Game Rounds", Category = "GameFuse|Rounds")
+	void BP_FetchMyGameRounds(const FString& GameType, int32 Page, int32 PerPage, const FBP_GFApiCallback& Callback);
+
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Game Rounds", Category = "GameFuse|Rounds")
-	void BP_FetchUserGameRounds(const FBP_GFApiCallback& Callback);
+	void BP_FetchUserGameRounds(int32 UserId, const FString& GameType, int32 Page, int32 PerPage, const FBP_GFApiCallback& Callback);
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Delete Game Round", Category = "GameFuse|Rounds")
 	void BP_DeleteGameRound(const int32 RoundId, const FBP_GFApiCallback& Callback);
@@ -43,7 +46,8 @@ public:
 	FGuid CreateGameRound(const FGFGameRound& GameRound, const FGFUserData& UserData, FGFGameRoundCallback TypedCallback);
 	FGuid FetchGameRound(const int32 RoundId, FGFGameRoundCallback TypedCallback);
 	FGuid UpdateGameRound(const int32 RoundId, const FGFGameRound& GameRound, FGFGameRoundCallback TypedCallback);
-	FGuid FetchUserGameRounds(FGFGameRoundListCallback TypedCallback);
+	FGuid FetchMyGameRounds(FGFGameRoundListCallback TypedCallback, const FString& GameType = "", int32 Page = 0, int32 PerPage = 0);
+	FGuid FetchUserGameRounds(int32 UserId, FGFGameRoundListCallback TypedCallback, const FString& GameType = "", int32 Page = 0, int32 PerPage = 0);
 	FGuid DeleteGameRound(const int32 RoundId, FGFGameRoundActionCallback TypedCallback);
 
 	// Getters for cached data
@@ -74,7 +78,8 @@ private:
 
 	// Internal response handlers
 	void HandleGameRoundResponse(FGFAPIResponse Response);
-	void HandleGameRoundListResponse(FGFAPIResponse Response);
+	void HandleMyGameRoundListResponse(FGFAPIResponse Response);
+	void HandleUserGameRoundListResponse(FGFAPIResponse Response);
 	void HandleDeleteResponse(FGFAPIResponse Response);
 
 	// User callbacks storage

--- a/Source/GameFuse/Public/Subsystems/GameFuseRounds.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseRounds.h
@@ -23,46 +23,147 @@ public:
 	virtual void Deinitialize() override;
 
 	//> Blueprint Callable Functions
+	/**
+	 * Creates a new game round (Blueprint version)
+	 * @param GameRound The game round data to create
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Create Game Round", Category = "GameFuse|Rounds")
 	void BP_CreateGameRound(const FGFGameRound& GameRound, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches a specific game round by ID (Blueprint version)
+	 * @param RoundId The ID of the round to fetch
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Game Round", Category = "GameFuse|Rounds")
 	void BP_FetchGameRound(const int32 RoundId, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Updates an existing game round (Blueprint version)
+	 * @param RoundId The ID of the round to update
+	 * @param GameRound Updated game round data
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Update Game Round", Category = "GameFuse|Rounds")
 	void BP_UpdateGameRound(const int32 RoundId, const FGFGameRound& GameRound, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches game rounds for the current user (Blueprint version)
+	 * @param GameType Optional game type filter
+	 * @param Page Page number for pagination
+	 * @param PerPage Number of rounds per page
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Game Rounds", Category = "GameFuse|Rounds")
 	void BP_FetchMyGameRounds(const FString& GameType, int32 Page, int32 PerPage, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Fetches game rounds for a specific user (Blueprint version)
+	 * @param UserId The user ID to fetch rounds for
+	 * @param GameType Optional game type filter
+	 * @param Page Page number for pagination
+	 * @param PerPage Number of rounds per page
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Game Rounds", Category = "GameFuse|Rounds")
 	void BP_FetchUserGameRounds(int32 UserId, const FString& GameType, int32 Page, int32 PerPage, const FBP_GFApiCallback& Callback);
 
+	/**
+	 * Deletes a game round (Blueprint version)
+	 * @param RoundId The ID of the round to delete
+	 * @param Callback Blueprint callback executed when the request completes
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Delete Game Round", Category = "GameFuse|Rounds")
 	void BP_DeleteGameRound(const int32 RoundId, const FBP_GFApiCallback& Callback);
 
 	// C++ callable functions with typed callbacks
+	/**
+	 * Creates a new game round
+	 * @param GameRound The game round data to create
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid CreateGameRound(const FGFGameRound& GameRound, FGFGameRoundCallback TypedCallback);
+	
+	/**
+	 * Creates a new game round with specific user data
+	 * @param GameRound The game round data to create
+	 * @param UserData User data for authentication
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid CreateGameRound(const FGFGameRound& GameRound, const FGFUserData& UserData, FGFGameRoundCallback TypedCallback);
+	
+	/**
+	 * Fetches a specific game round by ID
+	 * @param RoundId The ID of the round to fetch
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchGameRound(const int32 RoundId, FGFGameRoundCallback TypedCallback);
+	
+	/**
+	 * Updates an existing game round
+	 * @param RoundId The ID of the round to update
+	 * @param GameRound Updated game round data
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid UpdateGameRound(const int32 RoundId, const FGFGameRound& GameRound, FGFGameRoundCallback TypedCallback);
+	
+	/**
+	 * Fetches game rounds for the current user
+	 * @param TypedCallback Callback executed when the request completes
+	 * @param GameType Optional game type filter
+	 * @param Page Page number for pagination
+	 * @param PerPage Number of rounds per page
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchMyGameRounds(FGFGameRoundListCallback TypedCallback, const FString& GameType = "", int32 Page = 0, int32 PerPage = 0);
+	
+	/**
+	 * Fetches game rounds for a specific user
+	 * @param UserId The user ID to fetch rounds for
+	 * @param TypedCallback Callback executed when the request completes
+	 * @param GameType Optional game type filter
+	 * @param Page Page number for pagination
+	 * @param PerPage Number of rounds per page
+	 * @return Request ID for tracking
+	 */
 	FGuid FetchUserGameRounds(int32 UserId, FGFGameRoundListCallback TypedCallback, const FString& GameType = "", int32 Page = 0, int32 PerPage = 0);
+	
+	/**
+	 * Deletes a game round
+	 * @param RoundId The ID of the round to delete
+	 * @param TypedCallback Callback executed when the request completes
+	 * @return Request ID for tracking
+	 */
 	FGuid DeleteGameRound(const int32 RoundId, FGFGameRoundActionCallback TypedCallback);
 
 	// Getters for cached data
+	/**
+	 * Gets the cached list of user game rounds
+	 * @return The last fetched user game rounds
+	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|Rounds")
 	const TArray<FGFGameRound>& GetUserRounds() const
 	{
 		return UserGameRounds;
 	}
 
+	/**
+	 * Gets the request handler for direct API access
+	 * @return Pointer to the rounds API handler
+	 */
 	TObjectPtr<URoundsAPIHandler> GetRequestHandler() const
 	{
 		return RequestHandler;
 	}
 
-	// Clear cached rounds data
+	/**
+	 * Clears all cached rounds data
+	 */
 	void ClearRoundsData()
 	{
 		UserGameRounds.Empty();
@@ -77,9 +178,28 @@ private:
 	TArray<FGFGameRound> UserGameRounds;
 
 	// Internal response handlers
+	/**
+	 * Handles responses for single game round operations
+	 * @param Response The API response to process
+	 */
 	void HandleGameRoundResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for fetching current user's game rounds
+	 * @param Response The API response to process
+	 */
 	void HandleMyGameRoundListResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for fetching specific user's game rounds
+	 * @param Response The API response to process
+	 */
 	void HandleUserGameRoundListResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles responses for delete operations
+	 * @param Response The API response to process
+	 */
 	void HandleDeleteResponse(FGFAPIResponse Response);
 
 	// User callbacks storage

--- a/Source/GameFuse/Public/Subsystems/GameFuseUser.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseUser.h
@@ -79,6 +79,8 @@ public:
 	FGuid SignIn(const FString& Email, const FString& Password, FGFUserDataCallback TypedCallback);
 	FGuid SignIn(const FGFGameData& GameData, const FString& Email, const FString& Password, FGFUserDataCallback TypedCallback);
 
+	FGuid FetchUser(const int32 UserId, FGFUserDataCallback TypedCallback);
+
 	UFUNCTION(BlueprintCallable, DisplayName = "Log Out", Category = "GameFuse|User")
 	void LogOut(const FString& SaveSlotName = TEXT("GameFuseSaveSlot"));
 
@@ -123,6 +125,7 @@ public:
 	FString GetAttributeValue(const FString Key) const;
 
 	FGuid FetchMyAttributes(FGFAttributesCallback TypedCallback);
+
 	FGuid FetchUserAttributes(const int32 UserId, FGFAttributesCallback TypedCallback);
 	FGuid SyncLocalAttributes(FGFAttributesCallback TypedCallback);
 	FGuid SetAttribute(const FString& Key, const FString& Value, FGFAttributesCallback TypedCallback);

--- a/Source/GameFuse/Public/Subsystems/GameFuseUser.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseUser.h
@@ -23,6 +23,18 @@ DECLARE_DELEGATE_TwoParams(FGFStoreItemsCallback, bool, const TArray<FGFStoreIte
 DECLARE_DELEGATE_TwoParams(FGFLeaderboardEntriesCallback, bool, const TArray<FGFLeaderboardEntry>&);
 DECLARE_DELEGATE_TwoParams(FGFAttributesCallback, bool, const FGFAttributeList&);
 
+/**
+ * GameFuse User Subsystem for managing user authentication, data, and interactions.
+ * 
+ * This subsystem provides comprehensive functionality for user management including:
+ * - User authentication (sign up, sign in, log out)
+ * - User data management (scores, credits, attributes)
+ * - Store item management (purchase, remove, fetch)
+ * - Leaderboard functionality (add entries, fetch rankings)
+ * - Attribute system for custom user data
+ *
+ * The subsystem can be accessed from any UObject using GetWorld()->GetSubsystem<UGameFuseUser>()
+ */
 UCLASS()
 class GAMEFUSE_API UGameFuseUser : public UGameInstanceSubsystem
 {
@@ -31,7 +43,22 @@ class GAMEFUSE_API UGameFuseUser : public UGameInstanceSubsystem
 public:
 
 #pragma region Subsystem Initialization
+	/**
+	 * Initializes the GameFuse User subsystem.
+	 * 
+	 * Called automatically by Unreal Engine when the subsystem is created.
+	 * Sets up the API handler and initializes internal data structures.
+	 * 
+	 * @param Collection The subsystem collection being initialized
+	 */
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	
+	/**
+	 * Deinitializes the GameFuse User subsystem.
+	 * 
+	 * Called automatically by Unreal Engine when the subsystem is being destroyed.
+	 * Cleans up resources and clears stored data.
+	 */
 	virtual void Deinitialize() override;
 
 #pragma endregion
@@ -39,10 +66,45 @@ public:
 #pragma region Members
 private:
 
-	FGFUserData UserData;
+	/**
+	 * Current user data - represents the authenticated user's information.
+	 * This data is set during sign in and remains unchanged when fetching other users' data.
+	 */
+	FGFUserData CurrentUserData;
+
+	/**
+	 * Last fetched user data - represents the most recently fetched user information.
+	 * This can be either the current user's data or another user's data from FetchUser().
+	 * Used for general user data operations and is updated with each fetch operation.
+	 */
+	FGFUserData LastFetchedUserData;
+
+	/**
+	 * Attributes from the last fetch attributes API call.
+	 * Contains key-value pairs of custom data from the most recent attributes fetch operation.
+	 * Updated when fetching attributes for any user (current or other).
+	 */
 	TMap<FString, FString> Attributes;
+
+	/**
+	 * Locally modified attributes that haven't been synced to the server.
+	 * These are temporary changes made locally that will be sent to the server
+	 * when SyncLocalAttributes() is called.
+	 */
 	TMap<FString, FString> LocalAttributes;
+
+	/**
+	 * Store items from the last fetch store items API call.
+	 * Contains all store items from the most recent store items fetch operation.
+	 * Updated when fetching store items for any user (current or other).
+	 */
 	TArray<FGFStoreItem> PurchasedStoreItems;
+
+	/**
+	 * Leaderboard entries from the last fetch leaderboard entries API call.
+	 * Contains all leaderboard entries from the most recent leaderboard entries fetch operation.
+	 * Updated when fetching leaderboard entries for any user (current or other).
+	 */
 	TArray<FGFLeaderboardEntry> LeaderboardEntries;
 
 	UPROPERTY()
@@ -55,168 +117,827 @@ public:
 
 #pragma region Core User Data & Authentication
 
-	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
-	const FGFUserData& GetUserData() const;
 
+	/**
+	 * Gets the current user data.
+	 * 
+	 * Returns the complete user data structure for the authenticated user.
+	 * This data is set during sign in and remains unchanged when fetching other users' data.
+	 * Contains ID, username, email, scores, credits, and other metadata for the current user.
+	 * 
+	 * @return Reference to the current user data structure
+	 */
+	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
+	const FGFUserData& GetCurrentUserData() const;
+
+	/**
+	 * Gets the last fetched user's data.
+	 * 
+	 * Fetching any user will update this data.
+	 * Contains ID, username, email, scores, credits, and other metadata for the user.
+	 * 
+	 * @return Reference to the current user data structure
+	 */
+	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
+	const FGFUserData& GetLastFetchedUserData() const;
+
+	/**
+	 * Gets the current user's username.
+	 * 
+	 * Returns the username of the currently authenticated user.
+	 * This data comes from CurrentUser and is not affected by FetchUser() operations.
+	 * Returns empty string if no user is signed in.
+	 * 
+	 * @return The username as a string
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	FString GetUsername() const;
 
+	/**
+	 * Gets the number of times the current user has logged in.
+	 * 
+	 * Returns the total login count for the currently authenticated user.
+	 * This data comes from CurrentUser and is not affected by FetchUser() operations.
+	 * Returns 0 if no user is signed in.
+	 * 
+	 * @return The number of logins as an integer
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	int32 GetNumberOfLogins() const;
 
+	/**
+	 * Gets the timestamp of the current user's last login.
+	 * 
+	 * Returns the date/time string of when the current user last logged in.
+	 * This data comes from CurrentUser and is not affected by FetchUser() operations.
+	 * Returns empty string if no user is signed in.
+	 * 
+	 * @return The last login timestamp as a string
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	FString GetLastLogin() const;
 
+	/**
+	 * Checks if a user is currently signed in.
+	 * 
+	 * Returns true if a user is authenticated and signed in,
+	 * false otherwise.
+	 * 
+	 * @return True if user is signed in, false otherwise
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	bool IsSignedIn() const;
 
+	/**
+	 * Gets the current authentication token.
+	 * 
+	 * Returns the JWT token used for API authentication.
+	 * Returns empty string if no user is signed in.
+	 * 
+	 * @return The authentication token as a string
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	FString GetAuthenticationToken() const;
 
-	// C++ callable functions with typed callbacks
+	/**
+	 * Signs up a new user with the provided credentials.
+	 * 
+	 * Creates a new user account with the specified email, password, and username.
+	 * The callback will be triggered when the signup process completes.
+	 * 
+	 * @param Email The user's email address
+	 * @param Password The user's password
+	 * @param PasswordConfirmation Password confirmation (must match Password)
+	 * @param Username The desired username
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid SignUp(const FString& Email, const FString& Password, const FString& PasswordConfirmation, const FString& Username, FGFUserDataCallback TypedCallback);
+	
+	/**
+	 * Signs up a new user with game data and credentials.
+	 * 
+	 * Creates a new user account with the specified email, password, username, and game data.
+	 * The callback will be triggered when the signup process completes.
+	 * 
+	 * @param GameData Additional game-specific data to associate with the user
+	 * @param Email The user's email address
+	 * @param Password The user's password
+	 * @param PasswordConfirmation Password confirmation (must match Password)
+	 * @param Username The desired username
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid SignUp(const FGFGameData& GameData, const FString& Email, const FString& Password, const FString& PasswordConfirmation, const FString& Username, FGFUserDataCallback TypedCallback);
+	
+	/**
+	 * Signs in an existing user with email and password.
+	 * 
+	 * Authenticates a user with the provided credentials and loads their data.
+	 * The callback will be triggered when the signin process completes.
+	 * 
+	 * @param Email The user's email address
+	 * @param Password The user's password
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid SignIn(const FString& Email, const FString& Password, FGFUserDataCallback TypedCallback);
+	
+	/**
+	 * Signs in an existing user with game data, email and password.
+	 * 
+	 * Authenticates a user with the provided credentials and loads their data,
+	 * including additional game-specific information.
+	 * The callback will be triggered when the signin process completes.
+	 * 
+	 * @param GameData Additional game-specific data to associate with the session
+	 * @param Email The user's email address
+	 * @param Password The user's password
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid SignIn(const FGFGameData& GameData, const FString& Email, const FString& Password, FGFUserDataCallback TypedCallback);
 
+	/**
+	 * Fetches user data for a specific user ID.
+	 * 
+	 * Retrieves the complete user data for the specified user ID.
+	 * This can be used to get information about other users.
+	 * 
+	 * @param UserId The ID of the user to fetch
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid FetchUser(const int32 UserId, FGFUserDataCallback TypedCallback);
 
+	/**
+	 * Logs out the current user and clears local data.
+	 * 
+	 * Signs out the current user, clears authentication tokens,
+	 * and optionally saves the current state to a save slot.
+	 * 
+	 * @param SaveSlotName Optional save slot name for persisting data (default: "GameFuseSaveSlot")
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Log Out", Category = "GameFuse|User")
 	void LogOut(const FString& SaveSlotName = TEXT("GameFuseSaveSlot"));
 
 #pragma endregion
 #pragma region Score & Credits
 
+	/**
+	 * Gets the current user's score.
+	 * 
+	 * Returns the current score value for the authenticated user.
+	 * This data comes from CurrentUser and is not affected by FetchUser() operations.
+	 * Returns 0 if no user is signed in.
+	 * 
+	 * @return The current score as an integer
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	int32 GetScore() const;
 
+	/**
+	 * Gets the current user's credits.
+	 * 
+	 * Returns the current credits value for the authenticated user.
+	 * This data comes from CurrentUser and is not affected by FetchUser() operations.
+	 * Returns 0 if no user is signed in.
+	 * 
+	 * @return The current credits as an integer
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	int32 GetCredits() const;
 
+	/**
+	 * Adds to the current user's score.
+	 * 
+	 * Increases the user's score by the specified amount.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param AddScore The amount to add to the current score
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid AddScore(const int32 AddScore, FGFUserDataCallback TypedCallback);
+	
+	/**
+	 * Sets the current user's score to a specific value.
+	 * 
+	 * Replaces the user's current score with the specified value.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param SetScore The new score value to set
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid SetScore(const int32 SetScore, FGFUserDataCallback TypedCallback);
+	
+	/**
+	 * Adds to the current user's credits.
+	 * 
+	 * Increases the user's credits by the specified amount.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param AddCredits The amount to add to the current credits
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid AddCredits(const int32 AddCredits, FGFUserDataCallback TypedCallback);
+	
+	/**
+	 * Sets the current user's credits to a specific value.
+	 * 
+	 * Replaces the user's current credits with the specified value.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param SetCredits The new credits value to set
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid SetCredits(const int32 SetCredits, FGFUserDataCallback TypedCallback);
 
 #pragma endregion
 #pragma region Store Items
 
+	/**
+	 * Gets the list of store items from the last fetch store items API call.
+	 * 
+	 * Returns an array of all store items from the most recent store items fetch operation.
+	 * This data comes from the last fetch store items API call (could be current user or another user).
+	 * Returns empty array if no store items have been fetched.
+	 * 
+	 * @return Array of purchased store items
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	const TArray<FGFStoreItem>& GetPurchasedStoreItems() const;
 
+	/**
+	 * Purchases a store item for the current user.
+	 * 
+	 * Attempts to purchase the specified store item using the user's credits.
+	 * The callback will be triggered when the purchase completes.
+	 * 
+	 * @param StoreItemId The ID of the store item to purchase
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid PurchaseStoreItem(const int32 StoreItemId, FGFStoreItemsCallback TypedCallback);
+	
+	/**
+	 * Removes a store item from the current user's inventory.
+	 * 
+	 * Removes the specified store item from the user's purchased items.
+	 * The callback will be triggered when the removal completes.
+	 * 
+	 * @param StoreItemId The ID of the store item to remove
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid RemoveStoreItem(const int32 StoreItemId, FGFStoreItemsCallback TypedCallback);
+	
+	/**
+	 * Fetches all store items purchased by the current user.
+	 * 
+	 * Retrieves the complete list of store items that the current user has purchased.
+	 * The callback will be triggered when the fetch completes.
+	 * 
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid FetchMyPurchasedStoreItems(FGFStoreItemsCallback TypedCallback);
+	
+	/**
+	 * Fetches all store items purchased by a specific user.
+	 * 
+	 * Retrieves the complete list of store items that the specified user has purchased.
+	 * The callback will be triggered when the fetch completes.
+	 * 
+	 * @param UserId The ID of the user whose purchases to fetch
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid FetchUserPurchasedStoreItems(const int32 UserId, FGFStoreItemsCallback TypedCallback);
 
 #pragma endregion
 #pragma region Attributes
 
+	/**
+	 * Gets map of attributes from the GameFuse server
+	 *
+	 * This data comes from the last fetch attributes operation (could be current user or another user).
+	 * Returns empty map if no user data has been fetched.
+	 * 
+	 * @return Map of attribute keys to values
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	const TMap<FString, FString>& GetAttributes() const;
 
+	/**
+	 * Gets all attribute keys from the last fetch attributes API call.
+	 * 
+	 * Returns an array of all attribute keys from the most recent attributes fetch operation.
+	 * This data comes from the last fetch attributes API call (could be current user or another user).
+	 * Returns empty array if no attributes have been fetched.
+	 * 
+	 * @return Array of attribute keys
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	TArray<FString> GetAttributesKeys() const;
 
+	/**
+	 * Gets all locally modified attributes that haven't been synced.
+	 * 
+	 * Returns a map of attributes that have been modified locally but not yet
+	 * synchronized with the server. These are temporary changes for the current user.
+	 * 
+	 * @return Map of dirty attribute keys to values
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	const TMap<FString, FString>& GetDirtyAttributes() const;
 
+	/**
+	 * Gets the value of a specific attribute from the last fetch attributes API call.
+	 * 
+	 * Returns the value associated with the specified attribute key from the most recent attributes fetch operation.
+	 * This data comes from the last fetch attributes API call (could be current user or another user).
+	 * Returns empty string if the attribute doesn't exist.
+	 * 
+	 * @param Key The attribute key to look up
+	 * @return The attribute value as a string
+	 */
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|User")
 	FString GetAttributeValue(const FString Key) const;
 
+	/**
+	 * Fetches all attributes for the current user from the server.
+	 * 
+	 * Retrieves the complete list of attributes for the current user from the server.
+	 * The callback will be triggered when the fetch completes.
+	 * 
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid FetchMyAttributes(FGFAttributesCallback TypedCallback);
 
+	/**
+	 * Fetches all attributes for a specific user from the server.
+	 * 
+	 * Retrieves the complete list of attributes for the specified user from the server.
+	 * The callback will be triggered when the fetch completes.
+	 * 
+	 * @param UserId The ID of the user whose attributes to fetch
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid FetchUserAttributes(const int32 UserId, FGFAttributesCallback TypedCallback);
+	
+	/**
+	 * Synchronizes locally modified attributes with the server.
+	 * 
+	 * Sends all locally modified attributes to the server to update the user's data.
+	 * The callback will be triggered when the sync completes.
+	 * 
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid SyncLocalAttributes(FGFAttributesCallback TypedCallback);
+	
+	/**
+	 * Sets a single attribute for the current user.
+	 * 
+	 * Sets or updates the value of a specific attribute key for the current user.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param Key The attribute key to set
+	 * @param Value The value to assign to the attribute
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid SetAttribute(const FString& Key, const FString& Value, FGFAttributesCallback TypedCallback);
+	
+	/**
+	 * Sets multiple attributes for the current user.
+	 * 
+	 * Sets or updates multiple attribute key-value pairs for the current user.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param NewAttributes Map of attribute keys to values to set
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid SetAttributes(const TMap<FString, FString>& NewAttributes, FGFAttributesCallback TypedCallback);
+	
+	/**
+	 * Sets an attribute locally without syncing to server.
+	 * 
+	 * Sets or updates the value of a specific attribute key locally.
+	 * The change will be stored locally and can be synced later using SyncLocalAttributes.
+	 * 
+	 * @param SetKey The attribute key to set
+	 * @param SetValue The value to assign to the attribute
+	 */
 	void SetAttributeLocal(const FString& SetKey, const FString& SetValue);
+	
+	/**
+	 * Removes a single attribute for the current user.
+	 * 
+	 * Deletes the specified attribute key and its value for the current user.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param SetKey The attribute key to remove
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid RemoveAttribute(const FString& SetKey, FGFAttributesCallback TypedCallback);
+	
+	/**
+	 * Removes multiple attributes for the current user.
+	 * 
+	 * Deletes multiple attribute keys and their values for the current user.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param AttributeKeys Array of attribute keys to remove
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid RemoveAttributes(const TArray<FString>& AttributeKeys, FGFAttributesCallback TypedCallback);
 
 #pragma endregion
 #pragma region Leaderboards
 
+	/**
+	 * Gets the leaderboard entries from the last fetch leaderboard entries API call.
+	 * 
+	 * Returns an array of all leaderboard entries from the most recent leaderboard entries fetch operation.
+	 * This data comes from the last fetch leaderboard entries API call (could be current user or another user).
+	 * Returns empty array if no leaderboard entries have been fetched.
+	 * 
+	 * @return Array of leaderboard entries
+	 */
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
-	const TArray<FGFLeaderboardEntry>& GetMyLeaderboardEntries() const;
+	const TArray<FGFLeaderboardEntry>& GetLeaderboardEntries() const;
 
+	/**
+	 * Adds a leaderboard entry with metadata for the current user.
+	 * 
+	 * Creates a new leaderboard entry with the specified score and metadata.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param LeaderboardName The name of the leaderboard to add the entry to
+	 * @param Score The score value for the entry
+	 * @param Metadata Additional metadata to associate with the entry
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid AddLeaderboardEntry(const FString& LeaderboardName, const int32 Score, const TMap<FString, FString>& Metadata, FGFInternalSuccessCallback TypedCallback);
+	
+	/**
+	 * Adds a leaderboard entry for the current user.
+	 * 
+	 * Creates a new leaderboard entry with the specified score.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param LeaderboardName The name of the leaderboard to add the entry to
+	 * @param Score The score value for the entry
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid AddLeaderboardEntry(const FString& LeaderboardName, const int32 Score, FGFInternalSuccessCallback TypedCallback);
+	
+	/**
+	 * Clears a leaderboard entry for the current user.
+	 * 
+	 * Removes the current user's entry from the specified leaderboard.
+	 * The callback will be triggered when the operation completes.
+	 * 
+	 * @param LeaderboardName The name of the leaderboard to clear the entry from
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid ClearLeaderboardEntry(const FString& LeaderboardName, FGFInternalSuccessCallback TypedCallback);
+	
+	/**
+	 * Fetches leaderboard entries for the current user.
+	 * 
+	 * Retrieves leaderboard entries for the current user with optional filtering.
+	 * The callback will be triggered when the fetch completes.
+	 * 
+	 * @param Limit Maximum number of entries to retrieve
+	 * @param bOnePerUser If true, only one entry per user will be returned
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid FetchMyLeaderboardEntries(const int32 Limit, bool bOnePerUser, FGFLeaderboardEntriesCallback TypedCallback);
+	
+	/**
+	 * Fetches leaderboard entries for a specific user.
+	 * 
+	 * Retrieves leaderboard entries for the specified user with optional filtering.
+	 * The callback will be triggered when the fetch completes.
+	 * 
+	 * @param UserId The ID of the user whose entries to fetch
+	 * @param Limit Maximum number of entries to retrieve
+	 * @param bOnePerUser If true, only one entry per user will be returned
+	 * @param TypedCallback Callback function to handle the response
+	 * @return Unique identifier for tracking this request
+	 */
 	FGuid FetchUserLeaderboardEntries(const int32 UserId, const int32 Limit, bool bOnePerUser, FGFLeaderboardEntriesCallback TypedCallback);
 #pragma endregion
 #pragma region Blueprint Wrapper Functions
+	/**
+	 * Blueprint wrapper for user sign up.
+	 * 
+	 * Creates a new user account with the specified credentials.
+	 * Use this function in Blueprint graphs for user registration.
+	 * 
+	 * @param Email The user's email address
+	 * @param Password The user's password
+	 * @param PasswordConfirmation Password confirmation (must match Password)
+	 * @param Username The desired username
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Sign Up", Category = "GameFuse|User")
 	void BP_SignUp(const FString& Email, const FString& Password, const FString& PasswordConfirmation, const FString& Username, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for user sign in.
+	 * 
+	 * Authenticates an existing user with email and password.
+	 * Use this function in Blueprint graphs for user login.
+	 * 
+	 * @param Email The user's email address
+	 * @param Password The user's password
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Sign In", Category = "GameFuse|User")
 	void BP_SignIn(const FString& Email, const FString& Password, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for adding score.
+	 * 
+	 * Increases the current user's score by the specified amount.
+	 * Use this function in Blueprint graphs for score management.
+	 * 
+	 * @param Score The amount to add to the current score
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Add Score", Category = "GameFuse|User")
 	void BP_AddScore(const int32 Score, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for setting score.
+	 * 
+	 * Sets the current user's score to the specified value.
+	 * Use this function in Blueprint graphs for score management.
+	 * 
+	 * @param Score The new score value to set
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Set Score", Category = "GameFuse|User")
 	void BP_SetScore(const int32 Score, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for adding credits.
+	 * 
+	 * Increases the current user's credits by the specified amount.
+	 * Use this function in Blueprint graphs for credit management.
+	 * 
+	 * @param Credits The amount to add to the current credits
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Add Credits", Category = "GameFuse|User")
 	void BP_AddCredits(const int32 Credits, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for setting credits.
+	 * 
+	 * Sets the current user's credits to the specified value.
+	 * Use this function in Blueprint graphs for credit management.
+	 * 
+	 * @param Credits The new credits value to set
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Set Credits", Category = "GameFuse|User")
 	void BP_SetCredits(const int32 Credits, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for setting a single attribute.
+	 * 
+	 * Sets or updates the value of a specific attribute key for the current user.
+	 * Use this function in Blueprint graphs for attribute management.
+	 * 
+	 * @param Key The attribute key to set
+	 * @param Value The value to assign to the attribute
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Set Attribute", Category = "GameFuse|User")
 	void BP_SetAttribute(const FString& Key, const FString& Value, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for setting multiple attributes.
+	 * 
+	 * Sets or updates multiple attribute key-value pairs for the current user.
+	 * Use this function in Blueprint graphs for attribute management.
+	 * 
+	 * @param NewAttributes Map of attribute keys to values to set
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Set Attributes", Category = "GameFuse|User")
 	void BP_SetAttributes(const TMap<FString, FString>& NewAttributes, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for setting an attribute locally.
+	 * 
+	 * Sets or updates the value of a specific attribute key locally without syncing to server.
+	 * Use this function in Blueprint graphs for local attribute management.
+	 * 
+	 * @param Key The attribute key to set
+	 * @param Value The value to assign to the attribute
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Set Attribute Local", Category = "GameFuse|User")
 	void BP_SetAttributeLocal(const FString& Key, const FString& Value);
 
+	/**
+	 * Blueprint wrapper for removing a single attribute.
+	 * 
+	 * Deletes the specified attribute key and its value for the current user.
+	 * Use this function in Blueprint graphs for attribute management.
+	 * 
+	 * @param Key The attribute key to remove
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Remove Attribute", Category = "GameFuse|User")
 	void BP_RemoveAttribute(const FString& Key, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for removing multiple attributes.
+	 * 
+	 * Deletes multiple attribute keys and their values for the current user.
+	 * Use this function in Blueprint graphs for attribute management.
+	 * 
+	 * @param AttributeKeys Array of attribute keys to remove
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Remove Attributes", Category = "GameFuse|User")
 	void BP_RemoveAttributes(const TArray<FString>& AttributeKeys, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for fetching current user's attributes.
+	 * 
+	 * Retrieves the complete list of attributes for the current user from the server.
+	 * Use this function in Blueprint graphs for attribute management.
+	 * 
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Attributes", Category = "GameFuse|User")
 	void BP_FetchMyAttributes(FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for fetching a specific user's attributes.
+	 * 
+	 * Retrieves the complete list of attributes for the specified user from the server.
+	 * Use this function in Blueprint graphs for attribute management.
+	 * 
+	 * @param UserId The ID of the user whose attributes to fetch
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Attributes", Category = "GameFuse|User")
 	void BP_FetchUserAttributes(const int32 UserId, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for syncing local attributes.
+	 * 
+	 * Sends all locally modified attributes to the server to update the user's data.
+	 * Use this function in Blueprint graphs for attribute synchronization.
+	 * 
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Sync Local Attributes", Category = "GameFuse|User")
 	void BP_SyncLocalAttributes(FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for adding a leaderboard entry.
+	 * 
+	 * Creates a new leaderboard entry with the specified score for the current user.
+	 * Use this function in Blueprint graphs for leaderboard management.
+	 * 
+	 * @param LeaderboardName The name of the leaderboard to add the entry to
+	 * @param Score The score value for the entry
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Add Leaderboard Entry", Category = "GameFuse|User")
 	void BP_AddLeaderboardEntry(const FString& LeaderboardName, const int32 Score, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for adding a leaderboard entry with metadata.
+	 * 
+	 * Creates a new leaderboard entry with the specified score and metadata for the current user.
+	 * Use this function in Blueprint graphs for leaderboard management.
+	 * 
+	 * @param LeaderboardName The name of the leaderboard to add the entry to
+	 * @param Score The score value for the entry
+	 * @param Metadata Additional metadata to associate with the entry
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Add Leaderboard Entry With Attributes", Category = "GameFuse|User")
 	void BP_AddLeaderboardEntryWithAttributes(const FString& LeaderboardName, const int32 Score, const TMap<FString, FString>& Metadata, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for clearing a leaderboard entry.
+	 * 
+	 * Removes the current user's entry from the specified leaderboard.
+	 * Use this function in Blueprint graphs for leaderboard management.
+	 * 
+	 * @param LeaderboardName The name of the leaderboard to clear the entry from
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Clear Leaderboard Entry", Category = "GameFuse|User")
 	void BP_ClearLeaderboardEntry(const FString& LeaderboardName, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for fetching current user's leaderboard entries.
+	 * 
+	 * Retrieves leaderboard entries for the current user with optional filtering.
+	 * Use this function in Blueprint graphs for leaderboard management.
+	 * 
+	 * @param Limit Maximum number of entries to retrieve (max 100)
+	 * @param bOnePerUser If true, only one entry per user will be returned
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Leaderboard Entries", Category = "GameFuse|User", meta = (Limit = 100))
 	void BP_FetchMyLeaderboardEntries(const int32 Limit, bool bOnePerUser, FBP_GFApiCallback Callback);
+	
+	/**
+	 * Blueprint wrapper for fetching a specific user's leaderboard entries.
+	 * 
+	 * Retrieves leaderboard entries for the specified user with optional filtering.
+	 * Use this function in Blueprint graphs for leaderboard management.
+	 * 
+	 * @param UserId The ID of the user whose entries to fetch
+	 * @param Limit Maximum number of entries to retrieve (max 100)
+	 * @param bOnePerUser If true, only one entry per user will be returned
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Leaderboard Entries", Category = "GameFuse|User", meta = (Limit = 100))
 	void BP_FetchUserLeaderboardEntries(const int32 UserId, const int32 Limit, bool bOnePerUser, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for purchasing a store item.
+	 * 
+	 * Attempts to purchase the specified store item using the user's credits.
+	 * Use this function in Blueprint graphs for store management.
+	 * 
+	 * @param StoreItemId The ID of the store item to purchase
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Purchase Store Item", Category = "GameFuse|User")
 	void BP_PurchaseStoreItem(const int32 StoreItemId, FBP_GFApiCallback Callback);
 
+	/**
+	 * Blueprint wrapper for removing a store item.
+	 * 
+	 * Removes the specified store item from the user's purchased items.
+	 * Use this function in Blueprint graphs for store management.
+	 * 
+	 * @param StoreItemId The ID of the store item to remove
+	 * @param Callback Blueprint callback to handle the response
+	 */
 	UFUNCTION(BlueprintCallable, DisplayName = "Remove Store Item", Category = "GameFuse|User")
 	void BP_RemoveStoreItem(const int32 StoreItemId, FBP_GFApiCallback Callback);
 
-	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Purchased Store Items", Category = "GameFuse|User")
+	/**
+	 * Blueprint wrapper for fetching current user's purchased store items.
+	 * 
+	 * Retrieves the complete list of store items that the current user has purchased.
+	 * Use this function in Blueprint graphs for store management.
+	 * 
+	 * @param Callback Blueprint callback to handle the response
+	 */
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Purchased Store Items", Category = "GameFuse|User")
 	void BP_FetchMyPurchasedStoreItems(FBP_GFApiCallback Callback);
 
-	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Purchased Store Items", Category = "GameFuse|User")
+	/**
+	 * Blueprint wrapper for fetching a specific user's purchased store items.
+	 * 
+	 * Retrieves the complete list of store items that the specified user has purchased.
+	 * Use this function in Blueprint graphs for store management.
+	 * 
+	 * @param UserId The ID of the user whose purchases to fetch
+	 * @param Callback Blueprint callback to handle the response
+	 */
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Purchased Store Items", Category = "GameFuse|User")
 	void BP_FetchUserPurchasedStoreItems(const int32 UserId, FBP_GFApiCallback Callback);
 
 #pragma endregion
 #pragma region Internal
+	/**
+	 * Gets the internal API request handler.
+	 * 
+	 * Returns the UserAPIHandler instance used for making API requests.
+	 * This is primarily used internally by the subsystem.
+	 * 
+	 * @return Pointer to the UserAPIHandler instance
+	 */
 	TObjectPtr<UUserAPIHandler> GetRequestHandler() const
 	{
 		return RequestHandler;
@@ -226,11 +947,67 @@ protected:
 
 #pragma endregion
 #pragma region Response Handlers
-	bool HandleUserDataResponse(FGFAPIResponse Response, bool bLogIn = false);
+	/**
+	 * Handles user data response from API calls.
+	 * 
+	 * Processes the response from user-related API calls and updates internal data.
+	 * Called internally by the subsystem.
+	 * 
+	 * @param Response The API response to process
+	 * @param bUpdateCurrentUser If true, updates CurrentUserData (for sign in/up operations)
+	 *                           If false, updates LastFetchedUserData (for fetch operations)
+	 * @return True if the response was processed successfully
+	 */
+	bool HandleUserDataResponse(FGFAPIResponse Response, bool bUpdateCurrentUser = false);
+	
+	/**
+	 * Handles store items response from API calls.
+	 * 
+	 * Processes the response from store-related API calls and updates internal data.
+	 * Called internally by the subsystem.
+	 * 
+	 * @param Response The API response to process
+	 */
 	void HandleStoreItemsResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles leaderboard entries response from API calls.
+	 * 
+	 * Processes the response from leaderboard-related API calls and updates internal data.
+	 * Called internally by the subsystem.
+	 * 
+	 * @param Response The API response to process
+	 */
 	void HandleLeaderboardEntriesResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles attributes response from API calls.
+	 * 
+	 * Processes the response from attribute-related API calls and updates internal data.
+	 * Called internally by the subsystem.
+	 * 
+	 * @param Response The API response to process
+	 */
 	void HandleAttributesResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Handles general user action response from API calls.
+	 * 
+	 * Processes the response from general user action API calls.
+	 * Called internally by the subsystem.
+	 * 
+	 * @param Response The API response to process
+	 */
 	void HandleUserActionResponse(FGFAPIResponse Response);
+	
+	/**
+	 * Executes blueprint callbacks with API response data.
+	 * 
+	 * Converts API response data to blueprint-compatible format and executes
+	 * the appropriate blueprint callback. Called internally by the subsystem.
+	 * 
+	 * @param Response The API response to convert and send to blueprints
+	 */
 	void ExecuteBlueprintCallback(const FGFAPIResponse& Response);
 
 #pragma endregion

--- a/Source/GameFuse/Public/Subsystems/GameFuseUser.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseUser.h
@@ -30,11 +30,31 @@ class GAMEFUSE_API UGameFuseUser : public UGameInstanceSubsystem
 
 public:
 
-	//> Subsystem Initialization
+#pragma region Subsystem Initialization
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
 	virtual void Deinitialize() override;
 
-	//> Core User Data & Authentication
+#pragma endregion
+
+#pragma region Members
+private:
+
+	FGFUserData UserData;
+	TMap<FString, FString> Attributes;
+	TMap<FString, FString> LocalAttributes;
+	TArray<FGFStoreItem> PurchasedStoreItems;
+	TArray<FGFLeaderboardEntry> LeaderboardEntries;
+
+	UPROPERTY()
+	TObjectPtr<UGameFuseManager> GameFuseManager;
+	UPROPERTY()
+	TObjectPtr<UUserAPIHandler> RequestHandler;
+
+#pragma endregion
+public:
+
+#pragma region Core User Data & Authentication
+
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	const FGFUserData& GetUserData() const;
 
@@ -62,7 +82,9 @@ public:
 	UFUNCTION(BlueprintCallable, DisplayName = "Log Out", Category = "GameFuse|User")
 	void LogOut(const FString& SaveSlotName = TEXT("GameFuseSaveSlot"));
 
-	//> Score & Credits
+#pragma endregion
+#pragma region Score & Credits
+
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	int32 GetScore() const;
 
@@ -74,15 +96,20 @@ public:
 	FGuid AddCredits(const int32 AddCredits, FGFUserDataCallback TypedCallback);
 	FGuid SetCredits(const int32 SetCredits, FGFUserDataCallback TypedCallback);
 
-	//> Store Items
+#pragma endregion
+#pragma region Store Items
+
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	const TArray<FGFStoreItem>& GetPurchasedStoreItems() const;
 
 	FGuid PurchaseStoreItem(const int32 StoreItemId, FGFStoreItemsCallback TypedCallback);
 	FGuid RemoveStoreItem(const int32 StoreItemId, FGFStoreItemsCallback TypedCallback);
-	FGuid FetchPurchasedStoreItems(FGFStoreItemsCallback TypedCallback);
+	FGuid FetchMyPurchasedStoreItems(FGFStoreItemsCallback TypedCallback);
+	FGuid FetchUserPurchasedStoreItems(const int32 UserId, FGFStoreItemsCallback TypedCallback);
 
-	//> Attributes
+#pragma endregion
+#pragma region Attributes
+
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	const TMap<FString, FString>& GetAttributes() const;
 
@@ -95,14 +122,17 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "GameFuse|User")
 	FString GetAttributeValue(const FString Key) const;
 
-	FGuid FetchAttributes(FGFAttributesCallback TypedCallback);
+	FGuid FetchMyAttributes(FGFAttributesCallback TypedCallback);
+	FGuid FetchUserAttributes(const int32 UserId, FGFAttributesCallback TypedCallback);
 	FGuid SyncLocalAttributes(FGFAttributesCallback TypedCallback);
 	FGuid SetAttribute(const FString& Key, const FString& Value, FGFAttributesCallback TypedCallback);
 	FGuid SetAttributes(const TMap<FString, FString>& NewAttributes, FGFAttributesCallback TypedCallback);
 	void SetAttributeLocal(const FString& SetKey, const FString& SetValue);
 	FGuid RemoveAttribute(const FString& SetKey, FGFAttributesCallback TypedCallback);
 
-	//> Leaderboards
+#pragma endregion
+#pragma region Leaderboards
+
 	UFUNCTION(BlueprintPure, Category = "GameFuse|User")
 	const TArray<FGFLeaderboardEntry>& GetMyLeaderboardEntries() const;
 
@@ -110,8 +140,9 @@ public:
 	FGuid AddLeaderboardEntry(const FString& LeaderboardName, const int32 Score, FGFInternalSuccessCallback TypedCallback);
 	FGuid ClearLeaderboardEntry(const FString& LeaderboardName, FGFInternalSuccessCallback TypedCallback);
 	FGuid FetchMyLeaderboardEntries(const int32 Limit, bool bOnePerUser, FGFLeaderboardEntriesCallback TypedCallback);
-
-	//> Blueprint Wrapper Functions
+	FGuid FetchUserLeaderboardEntries(const int32 UserId, const int32 Limit, bool bOnePerUser, FGFLeaderboardEntriesCallback TypedCallback);
+#pragma endregion
+#pragma region Blueprint Wrapper Functions
 	UFUNCTION(BlueprintCallable, DisplayName = "Sign Up", Category = "GameFuse|User")
 	void BP_SignUp(const FString& Email, const FString& Password, const FString& PasswordConfirmation, const FString& Username, FBP_GFApiCallback Callback);
 
@@ -142,8 +173,11 @@ public:
 	UFUNCTION(BlueprintCallable, DisplayName = "Remove Attribute", Category = "GameFuse|User")
 	void BP_RemoveAttribute(const FString& Key, FBP_GFApiCallback Callback);
 
-	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Attributes", Category = "GameFuse|User")
-	void BP_FetchAttributes(FBP_GFApiCallback Callback);
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Attributes", Category = "GameFuse|User")
+	void BP_FetchMyAttributes(FBP_GFApiCallback Callback);
+
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Attributes", Category = "GameFuse|User")
+	void BP_FetchUserAttributes(const int32 UserId, FBP_GFApiCallback Callback);
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Sync Local Attributes", Category = "GameFuse|User")
 	void BP_SyncLocalAttributes(FBP_GFApiCallback Callback);
@@ -159,6 +193,8 @@ public:
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Leaderboard Entries", Category = "GameFuse|User", meta = (Limit = 100))
 	void BP_FetchMyLeaderboardEntries(const int32 Limit, bool bOnePerUser, FBP_GFApiCallback Callback);
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch User Leaderboard Entries", Category = "GameFuse|User", meta = (Limit = 100))
+	void BP_FetchUserLeaderboardEntries(const int32 UserId, const int32 Limit, bool bOnePerUser, FBP_GFApiCallback Callback);
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Purchase Store Item", Category = "GameFuse|User")
 	void BP_PurchaseStoreItem(const int32 StoreItemId, FBP_GFApiCallback Callback);
@@ -167,9 +203,13 @@ public:
 	void BP_RemoveStoreItem(const int32 StoreItemId, FBP_GFApiCallback Callback);
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Purchased Store Items", Category = "GameFuse|User")
-	void BP_FetchPurchasedStoreItems(FBP_GFApiCallback Callback);
+	void BP_FetchMyPurchasedStoreItems(FBP_GFApiCallback Callback);
 
-	//> Internal
+	UFUNCTION(BlueprintCallable, DisplayName = "Fetch Purchased Store Items", Category = "GameFuse|User")
+	void BP_FetchUserPurchasedStoreItems(const int32 UserId, FBP_GFApiCallback Callback);
+
+#pragma endregion
+#pragma region Internal
 	TObjectPtr<UUserAPIHandler> GetRequestHandler() const
 	{
 		return RequestHandler;
@@ -177,34 +217,22 @@ public:
 
 protected:
 
-	//> Response Handlers
+#pragma endregion
+#pragma region Response Handlers
 	bool HandleUserDataResponse(FGFAPIResponse Response, bool bLogIn = false);
 	void HandleStoreItemsResponse(FGFAPIResponse Response);
 	void HandleLeaderboardEntriesResponse(FGFAPIResponse Response);
 	void HandleAttributesResponse(FGFAPIResponse Response);
 	void HandleUserActionResponse(FGFAPIResponse Response);
-
-	//> Helper Functions
 	void ExecuteBlueprintCallback(const FGFAPIResponse& Response);
 
-private:
-
-	FGFUserData UserData;
-	TMap<FString, FString> Attributes;
-	TMap<FString, FString> LocalAttributes;
-	TArray<FGFStoreItem> PurchasedStoreItems;
-	TArray<FGFLeaderboardEntry> LeaderboardEntries;
-
-	UPROPERTY()
-	TObjectPtr<UGameFuseManager> GameFuseManager;
-	UPROPERTY()
-	TObjectPtr<UUserAPIHandler> RequestHandler;
-
-	//> Callback storage
+#pragma endregion
+#pragma region Callback storage
 	TMap<FGuid, FGFUserDataCallback> UserDataCallbacks;
 	TMap<FGuid, FGFStoreItemsCallback> StoreItemsCallbacks;
 	TMap<FGuid, FGFLeaderboardEntriesCallback> LeaderboardEntriesCallbacks;
 	TMap<FGuid, FGFAttributesCallback> AttributesCallbacks;
 	TMap<FGuid, FGFInternalSuccessCallback> SimpleSuccessCallbacks;
 	TMap<FGuid, FBP_GFApiCallback> BlueprintCallbacks; // Store blueprint callbacks
+#pragma endregion
 };

--- a/Source/GameFuse/Public/Subsystems/GameFuseUser.h
+++ b/Source/GameFuse/Public/Subsystems/GameFuseUser.h
@@ -132,6 +132,7 @@ public:
 	FGuid SetAttributes(const TMap<FString, FString>& NewAttributes, FGFAttributesCallback TypedCallback);
 	void SetAttributeLocal(const FString& SetKey, const FString& SetValue);
 	FGuid RemoveAttribute(const FString& SetKey, FGFAttributesCallback TypedCallback);
+	FGuid RemoveAttributes(const TArray<FString>& AttributeKeys, FGFAttributesCallback TypedCallback);
 
 #pragma endregion
 #pragma region Leaderboards
@@ -175,6 +176,9 @@ public:
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Remove Attribute", Category = "GameFuse|User")
 	void BP_RemoveAttribute(const FString& Key, FBP_GFApiCallback Callback);
+
+	UFUNCTION(BlueprintCallable, DisplayName = "Remove Attributes", Category = "GameFuse|User")
+	void BP_RemoveAttributes(const TArray<FString>& AttributeKeys, FBP_GFApiCallback Callback);
 
 	UFUNCTION(BlueprintCallable, DisplayName = "Fetch My Attributes", Category = "GameFuse|User")
 	void BP_FetchMyAttributes(FBP_GFApiCallback Callback);

--- a/Source/GameFuseTests/Private/Commands/TestSuiteCommands.cpp
+++ b/Source/GameFuseTests/Private/Commands/TestSuiteCommands.cpp
@@ -331,7 +331,7 @@ bool FSetupUser::Update()
 	if (bSignInSent && GameFuseUser->IsSignedIn()) {
 		UE_LOG(LogGameFuse, Log, TEXT("+++ User signed in successfully +++"));
 		Test->TestTrue("User should be signed in", GameFuseUser->IsSignedIn());
-		const FGFUserData& CurrentUserData = GameFuseUser->GetUserData();
+		const FGFUserData& CurrentUserData = GameFuseUser->GetCurrentUserData();
 		Test->TestEqual("User IDs should match", CurrentUserData.Id, UserData->Id);
 		Test->TestEqual("Usernames should match", CurrentUserData.Username, UserData->Username);
 

--- a/Source/GameFuseTests/Private/GameFuseTests.cpp
+++ b/Source/GameFuseTests/Private/GameFuseTests.cpp
@@ -1,40 +1,9 @@
 #include "GameFuseTests.h"
-#include "Library/GameFuseLog.h"
-#include "Misc/AutomationTest.h"
-#include "Subsystems/GameFuseManager.h"
 
 #define LOCTEXT_NAMESPACE "FGameFuseTestsModule"
 
 void FGameFuseTestsModule::StartupModule()
-{
-	FAutomationTestFramework::Get().OnBeforeAllTestsEvent.AddLambda([this]() {
-		// UE_LOG(LogGameFuse, Log, TEXT("GameFuse ====> OnBeforeAllTestsEvent"));
-		// UWorld* World = GEditor->GetEditorWorldContext().World();
-		// GameInstance = World->GetGameInstance();
-		// ensure(GameInstance);
-		// GameInstance->Init();
-		// GameFuseManager = GameInstance->GetSubsystem<UGameFuseManager>();
-		// GameData = MakeShared<FGFGameData>();
-		//
-		// TestAPIHandler = NewObject<UTestAPIHandler>();
-	});
-
-	FAutomationTestFramework::Get().OnAfterAllTestsEvent.AddLambda([]() {
-		UE_LOG(LogGameFuse, Log, TEXT("GameFuse ====> OnAfterAllTestsEvent"));
-	});
-
-	FAutomationTestFramework::Get().OnTestStartEvent.AddLambda([](FAutomationTestBase* Test) {
-		if (Test != nullptr) {
-			UE_LOG(LogGameFuse, Log, TEXT("Starting test: %s"), *Test->GetTestFullName());
-		}
-	});
-
-	FAutomationTestFramework::Get().OnTestEndEvent.AddLambda([](FAutomationTestBase* Test) {
-		if (Test != nullptr) {
-			UE_LOG(LogGameFuse, Log, TEXT("Ending test: %s"), *Test->GetTestFullName());
-		}
-	});
-}
+{}
 
 void FGameFuseTestsModule::ShutdownModule()
 {}

--- a/Source/GameFuseTests/Private/Tests/GameFuseFriends.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseFriends.spec.cpp
@@ -215,7 +215,7 @@ void GameFuseFriendsSpec::Define()
 									});
 
 									ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseFriends->GetRequestHandler(),
-																					  GameFuseFriends->FetchFriendsList(FriendsCallback)));
+																					  GameFuseFriends->FetchMyFriendsList(FriendsCallback)));
 									return true;
 								}));
 								return true;
@@ -570,10 +570,108 @@ void GameFuseFriendsSpec::Define()
 									});
 
 									ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseFriends->GetRequestHandler(),
-																					  GameFuseFriends->FetchFriendsList(VerifyCallback)));
+																					  GameFuseFriends->FetchMyFriendsList(VerifyCallback)));
 								});
 
 
+								return true;
+							}));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("fetches another users friend list", [this]()
+		{
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool
+			{
+				// Step 1: User1 sends a friend request to User2.
+				FGFFriendRequestCallback SendCallback;
+				SendCallback.BindLambda([this](const FGFFriendRequest& Request)
+				{
+					AddInfo("FetchUserFriendsList 1 :: Send Request");
+					TestTrue("FriendshipId should be valid", Request.FriendshipId > 0);
+				});
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseFriends->GetRequestHandler(),
+																  GameFuseFriends->SendFriendRequest(
+																	  UserData2->Username, SendCallback)));
+
+				// Step 2: User2 signs in.
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool
+				{
+					FGFUserDataCallback SignInCallback;
+					SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData)
+					{
+						AddInfo("FetchUserFriendsList 2 :: Sign In Second User");
+						TestTrue("Second user sign in succeeded", bSuccess);
+					});
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																	  GameFuseUser->SignIn(
+																		  UserData2->Username + "@gamefuse.com", "password",
+																		  SignInCallback)));
+
+					// Step 3: User2 fetches incoming requests and accepts.
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool
+					{
+						FGFFriendRequestsCallback FetchCallback;
+						FetchCallback.BindLambda([this](const TArray<FGFFriendRequest>& IncomingRequests)
+						{
+							AddInfo("FetchUserFriendsList 3 :: Fetch and Accept Request");
+							TestEqual("Should have one incoming request", IncomingRequests.Num(), 1);
+							if (IncomingRequests.Num() == 1)
+							{
+								FGFFriendActionCallback AcceptCallback;
+								AcceptCallback.BindLambda([this](bool bSuccess)
+								{
+									TestTrue("Accept friend request succeeded", bSuccess);
+								});
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseFriends->GetRequestHandler(),
+																				  GameFuseFriends->AcceptFriendRequest(
+																					  IncomingRequests[0].FriendshipId,
+																					  AcceptCallback)));
+							}
+						});
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseFriends->GetRequestHandler(),
+																		  GameFuseFriends->FetchIncomingFriendRequests(
+																			  FetchCallback)));
+
+						// Step 4: User1 signs back in.
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool
+						{
+							FGFUserDataCallback SignInCallback;
+							SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData)
+							{
+								AddInfo("FetchUserFriendsList 4 :: Sign In First User");
+								TestTrue("First user sign in succeeded", bSuccess);
+							});
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->SignIn(
+																				  UserData1->Username + "@gamefuse.com", "password",
+																				  SignInCallback)));
+
+							// Step 5: User1 fetches User2's friend list.
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool
+							{
+								FGFFriendsCallback FriendsCallback;
+								FriendsCallback.BindLambda([this](const TArray<FGFUserData>& Friends)
+								{
+									AddInfo("FetchUserFriendsList 5 :: Verify Friends List");
+									TestEqual("User2 should have exactly one friend", Friends.Num(), 1);
+									if (Friends.Num() == 1)
+									{
+										TestEqual("Friend Id should be User1's Id", Friends[0].Id, UserData1->Id);
+										TestEqual("Friend Username should be User1's Username", Friends[0].Username,
+												  UserData1->Username);
+									}
+								});
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseFriends->GetRequestHandler(),
+																				  GameFuseFriends->FetchUserFriendsList(
+																					  UserData2->Id, FriendsCallback)));
 								return true;
 							}));
 							return true;

--- a/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
@@ -130,7 +130,7 @@ void FGameFuseGroupsSpec::Define()
 				TestTrue("Group is searchable", CreatedGroup.bSearchable);
 
 				// Verify internal state matches callback data
-				const TArray<FGFGroup>& AllGroups = GameFuseGroups->GetAllGroups();
+				const TArray<FGFGroup>& AllGroups = GameFuseGroups->GetFetchedGroups();
 				TestTrue("Group is stored internally", AllGroups.Contains(CreatedGroup));
 			});
 
@@ -187,7 +187,7 @@ void FGameFuseGroupsSpec::Define()
 					FetchCallback.BindLambda([this](const TArray<FGFGroup>& Groups) {
 						AddInfo("FetchAllGroups 3 :: Verify Groups List");
 						TestTrue("Has at least two groups", Groups.Num() >= 2);
-						TestEqual("Internal storage matches callback data", Groups, GameFuseGroups->GetAllGroups());
+						TestEqual("Internal storage matches callback data", Groups, GameFuseGroups->GetFetchedGroups());
 
 						// Find our created groups in the list
 						bool bFoundGroup1 = false;

--- a/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
@@ -270,7 +270,7 @@ void FGameFuseGroupsSpec::Define()
 						AddErrorIfFalse(Connection.Id != 0, "Failed to join group");
 						TestTrue("Connection has valid id", Connection.Id != 0);
 						TestEqual("Connection has correct user id", Connection.User.Id, UserData2->Id);
-						TestNotEqual("Connection has status", Connection.Status, EGFInviteRequestStatus::None);
+						TestEqual("Connection has status", Connection.Status, EGFInviteRequestStatus::Accepted);
 
 						// Verify the connection was successful
 						TestTrue("Connection status indicates success",
@@ -517,7 +517,6 @@ void FGameFuseGroupsSpec::Define()
 					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
 																	  GameFuseGroups->AddAttribute(GroupData->Id, *ClanLevelAttribute, true, AddLevelCallback)));
 
-					// After adding level, add motto
 					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
 						FGFGroupAttribute ClanMottoAttribute;
 						ClanMottoAttribute.Key = TEXT("clan_motto");
@@ -673,6 +672,293 @@ void FGameFuseGroupsSpec::Define()
 				}));
 				return true;
 			}));
+		});
+
+		It("enforces creator-only edit permissions for attributes", [this]() {
+			TSharedPtr<FGFGroup> GroupData = MakeShared<FGFGroup>();
+			GroupData->Name = TEXT("Attribute Permissions Test Group");
+			GroupData->GroupType = TEXT("Test");
+			GroupData->MaxGroupSize = 10;
+			GroupData->bCanAutoJoin = true; // Make it auto-join
+			GroupData->bSearchable = true;
+
+			// Declare shared pointers for attributes once at test scope
+			TSharedPtr<FGFGroupAttribute> CreatorOnlyAttr = MakeShared<FGFGroupAttribute>();
+			TSharedPtr<FGFGroupAttribute> MemberEditableAttr = MakeShared<FGFGroupAttribute>();
+
+			// Create the group and attributes
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+				FGFGroupCallback CreateGroupCallback;
+				CreateGroupCallback.BindLambda([this, GroupData](const FGFGroup& CreatedGroup) {
+					AddInfo("AttributePermissions 1 :: Create Group");
+					TestTrue("Group created successfully", CreatedGroup.Id > 0);
+					GroupData->Id = CreatedGroup.Id;
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																  GameFuseGroups->CreateGroup(*GroupData, CreateGroupCallback)));
+
+				// Create creator-only attribute
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+					FGFGroupAttribute CreatorOnlyAttribute;
+					CreatorOnlyAttribute.Key = TEXT("secret_code");
+					CreatorOnlyAttribute.Value = TEXT("1234");
+					CreatorOnlyAttribute.CreatorId = GroupData->Id;
+
+					FGFGroupAttributeCallback AddCreatorOnlyAttributeCallback;
+					AddCreatorOnlyAttributeCallback.BindLambda([this, CreatorOnlyAttr](const TArray<FGFGroupAttribute>& Attributes) {
+						AddInfo("AttributePermissions 2 :: Add Creator-Only Attribute");
+						TestTrue("Attribute added successfully", Attributes.Num() > 0);
+						if (Attributes.Num() > 0) {
+							*CreatorOnlyAttr = Attributes[0];
+							TestEqual("Attribute has correct key", CreatorOnlyAttr->Key, TEXT("secret_code"));
+							TestEqual("Attribute has correct value", CreatorOnlyAttr->Value, TEXT("1234"));
+							TestEqual("Attribute has correct creator ID", CreatorOnlyAttr->CreatorId, UserData1->Id);
+							TestTrue("Attribute creator can edit", CreatorOnlyAttr->bCanEdit);
+						}
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																	  GameFuseGroups->AddAttribute(GroupData->Id, CreatorOnlyAttribute, false, AddCreatorOnlyAttributeCallback)));
+					// Create member-editable attribute
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+						FGFGroupAttribute MemberEditableAttribute;
+						MemberEditableAttribute.Key = TEXT("public_data");
+						MemberEditableAttribute.Value = TEXT("original_value");
+						MemberEditableAttribute.CreatorId = GroupData->Id;
+
+						FGFGroupAttributeCallback AddMemberAttributeCallback;
+						AddMemberAttributeCallback.BindLambda([this, MemberEditableAttr](const TArray<FGFGroupAttribute>& Attributes) {
+							AddInfo("AttributePermissions 3 :: Add Member-Editable Attribute");
+							TestTrue("Attribute added successfully", Attributes.Num() > 0);
+							if (Attributes.Num() > 0) {
+								*MemberEditableAttr = Attributes[0];
+								TestEqual("Attribute has correct key", MemberEditableAttr->Key, TEXT("public_data"));
+								TestEqual("Attribute has correct value", MemberEditableAttr->Value, TEXT("original_value"));
+								TestEqual("Attribute has correct creator ID", MemberEditableAttr->CreatorId, UserData1->Id);
+								TestTrue("Attribute creator can edit", MemberEditableAttr->bCanEdit);
+							}
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																		  GameFuseGroups->AddAttribute(GroupData->Id, MemberEditableAttribute, true, AddMemberAttributeCallback)));
+						// Sign in as second user to test attribute permissions
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+							FGFUserDataCallback SignInCallback;
+							SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+								AddInfo("AttributePermissions 4 :: Sign In Second User");
+								TestTrue("Second user sign in succeeded", bSuccess);
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+							// Join the group
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+								// Store the connection data for later use
+								TSharedPtr<FGFGroupConnection> ConnectionData = MakeShared<FGFGroupConnection>();
+
+								FGFGroupConnectionCallback JoinCallback;
+								JoinCallback.BindLambda([this, ConnectionData](const FGFGroupConnection& Connection) {
+									AddInfo("AttributePermissions 5 :: Join Group as Second User");
+									TestTrue("Connection has valid id", Connection.Id != 0);
+									TestEqual("Connection has correct user id", Connection.User.Id, UserData2->Id);
+									TestEqual("Connection status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+
+									// Store the connection data for later use
+									*ConnectionData = Connection;
+								});
+
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																				  GameFuseGroups->RequestToJoinGroup(GroupData->Id, JoinCallback)));
+
+								// Switch back to user 1 to accept the join request
+								ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr, ConnectionData]() -> bool {
+									FGFUserDataCallback SignInCallback;
+									SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+										AddInfo("AttributePermissions 6 :: Switch Back to Creator");
+										TestTrue("Creator sign in succeeded", bSuccess);
+									});
+
+									ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																					  GameFuseUser->SignIn(UserData1->Username + "@gamefuse.com", "password", SignInCallback)));
+
+									// Accept the join request with the stored connection data
+									ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr, ConnectionData]() -> bool {
+										if (ConnectionData->Id == 0) {
+											AddError("Connection data is not valid");
+											return true;
+										}
+
+										UE_LOG(LogGameFuse, Log, TEXT("Accepting connection - ID: %d, User ID: %d"), ConnectionData->Id, ConnectionData->User.Id);
+
+										FGFGroupActionCallback AcceptCallback;
+										AcceptCallback.BindLambda([this](bool bSuccess) {
+											AddInfo("AttributePermissions 7 :: Accept Join Request");
+											TestTrue("Accept join request succeeded", bSuccess);
+										});
+
+										ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																						  GameFuseGroups->RespondToGroupJoinRequest(ConnectionData->Id, ConnectionData->User.Id, EGFInviteRequestStatus::Accepted, AcceptCallback)));
+
+										// Now switch back to user 2 to test editing attributes
+										ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+											FGFUserDataCallback SignInCallback;
+											SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+												AddInfo("AttributePermissions 8 :: Switch Back to Second User");
+												TestTrue("Second user sign in succeeded", bSuccess);
+											});
+
+											ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																							  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+											// Fetch attributes as second user
+											ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+												FGFGroupAttributeCallback FetchCallback;
+												FetchCallback.BindLambda([this, CreatorOnlyAttr, MemberEditableAttr](const TArray<FGFGroupAttribute>& Attributes) {
+													AddInfo("AttributePermissions 9 :: Fetch Attributes as Second User");
+													TestEqual("Both attributes fetched successfully", Attributes.Num(), 2);
+
+													for (const FGFGroupAttribute& Attribute : Attributes) {
+														if (Attribute.Key == TEXT("secret_code")) {
+															*CreatorOnlyAttr = Attribute;
+															TestEqual("Secret code has correct value", Attribute.Value, TEXT("1234"));
+															TestFalse("Second user cannot edit creator-only attribute", Attribute.bCanEdit);
+														} else if (Attribute.Key == TEXT("public_data")) {
+															*MemberEditableAttr = Attribute;
+															TestEqual("Public data has correct value", Attribute.Value, TEXT("original_value"));
+															TestTrue("Second user can edit member-editable attribute", Attribute.bCanEdit);
+														}
+													}
+												});
+
+												ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																								  GameFuseGroups->FetchGroupAttributes(GroupData->Id, FetchCallback)));
+
+												// Try to update creator-only attribute (should fail)
+												ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+													CreatorOnlyAttr->Value = TEXT("5678");
+
+													FGFGroupActionCallback UpdateCreatorOnlyCallback;
+													UpdateCreatorOnlyCallback.BindLambda([this](bool bSuccess) {
+														AddInfo("AttributePermissions 10 :: Try Update Creator-Only as Second User");
+														TestFalse("Update should fail for non-creator", bSuccess);
+													});
+
+													ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																									  GameFuseGroups->UpdateGroupAttribute(GroupData->Id, *CreatorOnlyAttr, UpdateCreatorOnlyCallback)));
+
+													// Try to update member-editable attribute (should succeed)
+													ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+														MemberEditableAttr->Value = TEXT("updated_by_member");
+
+														FGFGroupActionCallback UpdateMemberEditableCallback;
+														UpdateMemberEditableCallback.BindLambda([this](bool bSuccess) {
+															AddInfo("AttributePermissions 11 :: Try Update Member-Editable as Second User");
+															TestTrue("Update should succeed for member-editable attribute", bSuccess);
+														});
+
+														ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																										  GameFuseGroups->UpdateGroupAttribute(GroupData->Id, *MemberEditableAttr, UpdateMemberEditableCallback)));
+
+														// Switch back to creator to verify changes
+														ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+															FGFUserDataCallback SignInCallback;
+															SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+																AddInfo("AttributePermissions 12 :: Sign Back In as Creator");
+																TestTrue("Creator sign in succeeded", bSuccess);
+															});
+
+															ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																											  GameFuseUser->SignIn(UserData1->Username + "@gamefuse.com", "password", SignInCallback)));
+
+															// Verify attribute states
+															ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
+																FGFGroupAttributeCallback FetchCallback;
+																FetchCallback.BindLambda([this, CreatorOnlyAttr, MemberEditableAttr](const TArray<FGFGroupAttribute>& Attributes) {
+																	AddInfo("AttributePermissions 13 :: Verify Attributes as Creator");
+																	TestEqual("Both attributes still exist", Attributes.Num(), 2);
+
+																	for (const FGFGroupAttribute& Attribute : Attributes) {
+																		if (Attribute.Key == TEXT("secret_code")) {
+																			*CreatorOnlyAttr = Attribute;
+																			TestEqual("Creator-only attribute still has original value", Attribute.Value, TEXT("1234"));
+																			TestTrue("Creator can edit attribute", Attribute.bCanEdit);
+																		} else if (Attribute.Key == TEXT("public_data")) {
+																			*MemberEditableAttr = Attribute;
+																			TestEqual("Member-editable attribute has updated value", Attribute.Value, TEXT("updated_by_member"));
+																			TestTrue("Creator can edit attribute", Attribute.bCanEdit);
+																		}
+																	}
+																});
+
+																ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																												  GameFuseGroups->FetchGroupAttributes(GroupData->Id, FetchCallback)));
+
+																// Update creator-only attribute as creator
+																ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr]() -> bool {
+																	CreatorOnlyAttr->Value = TEXT("9999");
+
+																	FGFGroupActionCallback UpdateCallback;
+																	UpdateCallback.BindLambda([this](bool bSuccess) {
+																		AddInfo("AttributePermissions 14 :: Update Creator-Only as Creator");
+																		TestTrue("Update should succeed for creator", bSuccess);
+																	});
+
+																	ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																													  GameFuseGroups->UpdateGroupAttribute(GroupData->Id, *CreatorOnlyAttr, UpdateCallback)));
+
+																	// Final verification
+																	ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+																		FGFGroupAttributeCallback VerifyCallback;
+																		VerifyCallback.BindLambda([this](const TArray<FGFGroupAttribute>& FinalAttributes) {
+																			AddInfo("AttributePermissions 15 :: Final Verification");
+																			TestEqual("Both attributes still exist", FinalAttributes.Num(), 2);
+
+																			for (const FGFGroupAttribute& Attribute : FinalAttributes) {
+																				if (Attribute.Key == TEXT("secret_code")) {
+																					TestEqual("Creator-only attribute has updated value", Attribute.Value, TEXT("9999"));
+																					TestTrue("Creator can still edit attribute", Attribute.bCanEdit);
+																				} else if (Attribute.Key == TEXT("public_data")) {
+																					TestEqual("Member-editable attribute still has member-updated value", Attribute.Value, TEXT("updated_by_member"));
+																					TestTrue("Creator can still edit attribute", Attribute.bCanEdit);
+																				}
+																			}
+																		});
+
+																		ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																														  GameFuseGroups->FetchGroupAttributes(GroupData->Id, VerifyCallback)));
+																		return true;
+																	}));
+																	return true;
+																}));
+																return true;
+															}));
+															return true;
+														}));
+														return true;
+													}));
+													return true;
+												}));
+												return true;
+											}));
+											return true;
+										}));
+										return true;
+									}));
+									return true;
+								}));
+								return true;
+							}));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+			return true;
 		});
 	});
 }

--- a/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
@@ -296,7 +296,7 @@ void FGameFuseGroupsSpec::Define()
 			GroupData->GroupType = "Test";
 			GroupData->MaxGroupSize = 10;
 			GroupData->bCanAutoJoin = false;
-			GroupData->bIsInviteOnly = true;
+			GroupData->bIsInviteOnly = false;
 			GroupData->bSearchable = true;
 
 			FGFGroupCallback CreateCallback;
@@ -305,7 +305,7 @@ void FGameFuseGroupsSpec::Define()
 				TestTrue("Created group has valid id", CreatedGroup.Id != 0);
 				TestEqual("Created group has correct name", CreatedGroup.Name, "Test Group for Join Request Accept");
 				TestFalse("Created group cannot auto join", CreatedGroup.bCanAutoJoin);
-				TestTrue("Created group is invite only", CreatedGroup.bIsInviteOnly);
+				TestFalse("Created group is not invite only", CreatedGroup.bIsInviteOnly);
 
 				GroupData->Id = CreatedGroup.Id;
 			});
@@ -388,7 +388,7 @@ void FGameFuseGroupsSpec::Define()
 			GroupData->GroupType = "Test";
 			GroupData->MaxGroupSize = 10;
 			GroupData->bCanAutoJoin = false;
-			GroupData->bIsInviteOnly = true;
+			GroupData->bIsInviteOnly = false;
 			GroupData->bSearchable = true;
 
 			FGFGroupCallback CreateCallback;
@@ -397,7 +397,7 @@ void FGameFuseGroupsSpec::Define()
 				TestTrue("Created group has valid id", CreatedGroup.Id != 0);
 				TestEqual("Created group has correct name", CreatedGroup.Name, "Test Group for Join Request Decline");
 				TestFalse("Created group cannot auto join", CreatedGroup.bCanAutoJoin);
-				TestTrue("Created group is invite only", CreatedGroup.bIsInviteOnly);
+				TestFalse("Created group is not invite only", CreatedGroup.bIsInviteOnly);
 
 				GroupData->Id = CreatedGroup.Id;
 			});
@@ -763,7 +763,7 @@ void FGameFuseGroupsSpec::Define()
 									AddInfo("AttributePermissions 5 :: Join Group as Second User");
 									TestTrue("Connection has valid id", Connection.Id != 0);
 									TestEqual("Connection has correct user id", Connection.User.Id, UserData2->Id);
-									TestEqual("Connection status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+									TestEqual("Connection status is accepted", Connection.Status, EGFInviteRequestStatus::Accepted);
 
 									// Store the connection data for later use
 									*ConnectionData = Connection;

--- a/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
@@ -1165,7 +1165,7 @@ void FGameFuseGroupsSpec::Define()
 			}));
 		});
 
-		It("manages group invites", [this]() {
+		It("invites a user to a invite only group", [this]() {
 			// Create a test group that is invite-only
 			TSharedPtr<FGFGroup> GroupData = MakeShared<FGFGroup>();
 			GroupData->Name = TEXT("Group Invites Test Group");
@@ -1176,181 +1176,137 @@ void FGameFuseGroupsSpec::Define()
 			GroupData->bSearchable = true;
 
 			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+				// User 1 (already signed in) creates the invite-only group
 				FGFGroupCallback CreateGroupCallback;
 				CreateGroupCallback.BindLambda([this, GroupData](const FGFGroup& CreatedGroup) {
-					AddInfo("GroupInvites 1 :: Create Invite-Only Group");
+					AddInfo("GroupInvites 1 :: User 1 Creates Invite-Only Group");
 					TestTrue("Group created successfully", CreatedGroup.Id > 0);
 					TestTrue("Group is invite only", CreatedGroup.bIsInviteOnly);
+					TestFalse("Group cannot auto join", CreatedGroup.bCanAutoJoin);
 					GroupData->Id = CreatedGroup.Id;
 				});
 
 				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
 																  GameFuseGroups->CreateGroup(*GroupData, CreateGroupCallback)));
 
-				// Fetch the group to verify initial state (no invites, no join requests)
+				// User 1 invites User 2 to the group
 				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
-					FGFGroupCallback FetchGroupCallback;
-					FetchGroupCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
-						AddInfo("GroupInvites 2 :: Verify Initial Group State");
-						TestTrue("Group fetched successfully", FetchedGroup.Id == GroupData->Id);
-						TestTrue("Group is invite only", FetchedGroup.bIsInviteOnly);
-						
-						// Initially, the group should have no invites or join requests
-						TestEqual("Group has no invites initially", FetchedGroup.Invites.Num(), 0);
-						TestEqual("Group has no join requests initially", FetchedGroup.JoinRequests.Num(), 0);
-						
-						// Verify the group only has the creator as a member
-						TestEqual("Group has only creator as member", FetchedGroup.Members.Num(), 1);
-						if (FetchedGroup.Members.Num() > 0) {
-							TestEqual("Creator is the only member", FetchedGroup.Members[0].Id, UserData1->Id);
+					FGFGroupConnectionCallback InviteCallback;
+					InviteCallback.BindLambda([this](const FGFGroupConnection& Connection) {
+						AddInfo("GroupInvites 2 :: User 1 Invites User 2");
+						if (Connection.Id == 0) {
+							AddError("Invite failed - connection ID is 0");
+							return;
 						}
+						TestTrue("Invite created successfully", Connection.Id != 0);
+						TestEqual("Invite has correct user id", Connection.User.Id, UserData2->Id);
+						TestEqual("Invite status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+
+						// Store the connection data for later use
+						TestConnectionData = MakeShared<FGFGroupConnection>(Connection);
 					});
 
 					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
-																	  GameFuseGroups->FetchGroup(GroupData->Id, FetchGroupCallback)));
+																	  GameFuseGroups->InviteGroupMember(GroupData->Id, UserData2->Id, InviteCallback)));
 
-					// Create second user and invite them to the group
+					// Fetch the group to verify the invite was created
 					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
-						FGFUserDataCallback SignInCallback;
-						SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
-							AddInfo("GroupInvites 3 :: Sign In Second User");
-							TestTrue("Second user sign in succeeded", bSuccess);
+						FGFGroupCallback FetchGroupCallback;
+						FetchGroupCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+							AddInfo("GroupInvites 3 :: Verify Group Has Invite");
+							TestTrue("Group fetched successfully", FetchedGroup.Id == GroupData->Id);
+							TestTrue("Group is invite only", FetchedGroup.bIsInviteOnly);
+							
+							// The group should now have an invite
+							TestTrue("Group has invites", FetchedGroup.Invites.Num() > 0);
+							
+							// Verify the invite details
+							bool bFoundInvite = false;
+							for (const FGFGroupConnection& Invite : FetchedGroup.Invites) {
+								if (Invite.User.Id == UserData2->Id) {
+									bFoundInvite = true;
+									TestEqual("Invite status is pending", Invite.Status, EGFInviteRequestStatus::Pending);
+									TestEqual("Invite user ID matches", Invite.User.Id, UserData2->Id);
+									TestEqual("Invite username matches", Invite.User.Username, UserData2->Username);
+									break;
+								}
+							}
+							TestTrue("Found the invite for user 2", bFoundInvite);
+							
+							// Verify no join requests exist for this invite-only group
+							TestEqual("Group has no join requests", FetchedGroup.JoinRequests.Num(), 0);
 						});
 
-						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
-																		  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																		  GameFuseGroups->FetchGroup(GroupData->Id, FetchGroupCallback)));
 
-						// Switch back to first user (admin) to invite the second user
+						// Switch to User 2 to accept the invite
 						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
 							FGFUserDataCallback SignInCallback;
 							SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
-								AddInfo("GroupInvites 4 :: Switch Back to Admin");
-								TestTrue("Admin sign in succeeded", bSuccess);
+								AddInfo("GroupInvites 4 :: Sign In User 2");
+								TestTrue("User 2 sign in succeeded", bSuccess);
 							});
 
 							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
-																			  GameFuseUser->SignIn(UserData1->Username + "@gamefuse.com", "password", SignInCallback)));
+																			  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
 
-							// Admin invites the second user to the group
+							// User 2 accepts the invite
 							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
-								FGFGroupConnectionCallback InviteCallback;
-								InviteCallback.BindLambda([this](const FGFGroupConnection& Connection) {
-									AddInfo("GroupInvites 5 :: Admin Invites Second User");
-									if (Connection.Id == 0) {
-										AddError("Invite failed - connection ID is 0");
-										return;
-									}
-									TestTrue("Invite created successfully", Connection.Id != 0);
-									TestEqual("Invite has correct user id", Connection.User.Id, UserData2->Id);
-									TestEqual("Invite status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+								if (!TestConnectionData.IsValid()) {
+									AddError("Connection data is not valid");
+									return true;
+								}
 
-									// Store the connection data for later use
-									TestConnectionData = MakeShared<FGFGroupConnection>(Connection);
+								if (TestConnectionData->Id == 0) {
+									AddError("Cannot accept invite - connection ID is 0");
+									return true;
+								}
+
+								FGFGroupActionCallback AcceptCallback;
+								AcceptCallback.BindLambda([this](bool bSuccess) {
+									AddInfo("GroupInvites 5 :: User 2 Accepts Invite");
+									TestTrue("Accept invite succeeded", bSuccess);
 								});
 
 								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
-																				  GameFuseGroups->InviteGroupMember(GroupData->Id, UserData2->Id, InviteCallback)));
+																				  GameFuseGroups->RespondToGroupJoinRequest(TestConnectionData->Id, TestConnectionData->User.Id, EGFInviteRequestStatus::Accepted, AcceptCallback)));
 
-								// Fetch the group to verify the invite was created
+								// Verify the group membership after accepting
 								ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
-									FGFGroupCallback FetchGroupCallback;
-									FetchGroupCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
-										AddInfo("GroupInvites 6 :: Verify Group Has Invite");
-										TestTrue("Group fetched successfully", FetchedGroup.Id == GroupData->Id);
-										TestTrue("Group is invite only", FetchedGroup.bIsInviteOnly);
+									FGFGroupCallback VerifyCallback;
+									VerifyCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+										AddInfo("GroupInvites 6 :: Verify Group Membership After Accept");
+										TestTrue("Group has members", FetchedGroup.Members.Num() >= 2);
 										
-										// The group should now have an invite
-										TestTrue("Group has invites", FetchedGroup.Invites.Num() > 0);
+										// Check if both users are now members
+										bool bFoundUser1Member = false;
+										bool bFoundUser2Member = false;
+										for (const FGFUserData& Member : FetchedGroup.Members) {
+											if (Member.Id == UserData1->Id) {
+												bFoundUser1Member = true;
+												TestEqual("User 1 member username matches", Member.Username, UserData1->Username);
+											} else if (Member.Id == UserData2->Id) {
+												bFoundUser2Member = true;
+												TestEqual("User 2 member username matches", Member.Username, UserData2->Username);
+											}
+										}
+										TestTrue("User 1 is still a member", bFoundUser1Member);
+										TestTrue("User 2 is now a member", bFoundUser2Member);
 										
-										// Verify the invite details
-										bool bFoundInvite = false;
+										// Verify invites are empty or the invite is no longer pending
+										bool bHasPendingInvites = false;
 										for (const FGFGroupConnection& Invite : FetchedGroup.Invites) {
-											if (Invite.User.Id == UserData2->Id) {
-												bFoundInvite = true;
-												TestEqual("Invite status is pending", Invite.Status, EGFInviteRequestStatus::Pending);
-												TestEqual("Invite user ID matches", Invite.User.Id, UserData2->Id);
-												TestEqual("Invite username matches", Invite.User.Username, UserData2->Username);
+											if (Invite.User.Id == UserData2->Id && Invite.Status == EGFInviteRequestStatus::Pending) {
+												bHasPendingInvites = true;
 												break;
 											}
 										}
-										TestTrue("Found the invite for second user", bFoundInvite);
-										
-										// Verify no join requests exist for this invite-only group
-										TestEqual("Group has no join requests", FetchedGroup.JoinRequests.Num(), 0);
+										TestFalse("No pending invites for accepted user", bHasPendingInvites);
 									});
 
 									ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
-																					  GameFuseGroups->FetchGroup(GroupData->Id, FetchGroupCallback)));
-
-									// Switch to second user to accept the invite
-									ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
-										FGFUserDataCallback SignInCallback;
-										SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
-											AddInfo("GroupInvites 7 :: Switch to Second User");
-											TestTrue("Second user sign in succeeded", bSuccess);
-										});
-
-										ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
-																						  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
-
-										// Second user accepts the invite
-										ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
-											if (!TestConnectionData.IsValid()) {
-												AddError("Connection data is not valid");
-												return true;
-											}
-
-											if (TestConnectionData->Id == 0) {
-												AddError("Cannot accept invite - connection ID is 0");
-												return true;
-											}
-
-											FGFGroupActionCallback AcceptCallback;
-											AcceptCallback.BindLambda([this](bool bSuccess) {
-												AddInfo("GroupInvites 8 :: Second User Accepts Invite");
-												TestTrue("Accept invite succeeded", bSuccess);
-											});
-
-											ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
-																							  GameFuseGroups->RespondToGroupJoinRequest(TestConnectionData->Id, TestConnectionData->User.Id, EGFInviteRequestStatus::Accepted, AcceptCallback)));
-
-											// Verify the group membership after accepting
-											ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
-												FGFGroupCallback VerifyCallback;
-												VerifyCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
-													AddInfo("GroupInvites 9 :: Verify Group Membership After Accept");
-													TestTrue("Group has members", FetchedGroup.Members.Num() > 0);
-													
-													// Check if second user is now a member
-													bool bFoundMember = false;
-													for (const FGFUserData& Member : FetchedGroup.Members) {
-														if (Member.Id == UserData2->Id) {
-															bFoundMember = true;
-															TestEqual("Member username matches", Member.Username, UserData2->Username);
-															break;
-														}
-													}
-													TestTrue("Second user is now a member", bFoundMember);
-													
-													// Verify invites are empty or the invite is no longer pending
-													bool bHasPendingInvites = false;
-													for (const FGFGroupConnection& Invite : FetchedGroup.Invites) {
-														if (Invite.User.Id == UserData2->Id && Invite.Status == EGFInviteRequestStatus::Pending) {
-															bHasPendingInvites = true;
-															break;
-														}
-													}
-													TestFalse("No pending invites for accepted user", bHasPendingInvites);
-												});
-
-												ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
-																								  GameFuseGroups->FetchGroup(GroupData->Id, VerifyCallback)));
-												return true;
-											}));
-											return true;
-										}));
-										return true;
-									}));
+																					  GameFuseGroups->FetchGroup(GroupData->Id, VerifyCallback)));
 									return true;
 								}));
 								return true;

--- a/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseGroups.spec.cpp
@@ -358,6 +358,11 @@ void FGameFuseGroupsSpec::Define()
 								return true;
 							}
 
+							if (TestConnectionData->Id == 0) {
+								AddError("Cannot accept join request - connection ID is 0");
+								return true;
+							}
+
 							UE_LOG(LogGameFuse, Log, TEXT("Using connection data - ID: %d, User ID: %d"), TestConnectionData->Id, TestConnectionData->User.Id);
 
 							FGFGroupActionCallback AcceptCallback;
@@ -421,6 +426,10 @@ void FGameFuseGroupsSpec::Define()
 					FGFGroupConnectionCallback RequestCallback;
 					RequestCallback.BindLambda([this](const FGFGroupConnection& Connection) {
 						AddInfo("DeclineJoinRequest 3 :: Request to Join");
+						if (Connection.Id == 0) {
+							AddError("Join request failed - connection ID is 0");
+							return;
+						}
 						TestTrue("Connection has valid id", Connection.Id != 0);
 						TestEqual("Connection has correct user id", Connection.User.Id, UserData2->Id);
 						TestEqual("Connection status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
@@ -433,7 +442,7 @@ void FGameFuseGroupsSpec::Define()
 																	  GameFuseGroups->RequestToJoinGroup(GroupData->Id, RequestCallback)));
 
 					// Sign back in as first user to decline the request
-					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
 						FGFUserDataCallback SignInCallback;
 						SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
 							AddInfo("SignIn :: User Data");
@@ -444,9 +453,14 @@ void FGameFuseGroupsSpec::Define()
 																		  GameFuseUser->SignIn(UserData1->Username + "@gamefuse.com", "password", SignInCallback)));
 
 						// Decline the join request using the stored connection data
-						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
 							if (!TestConnectionData.IsValid()) {
 								AddError("Connection data is not valid");
+								return true;
+							}
+
+							if (TestConnectionData->Id == 0) {
+								AddError("Cannot decline join request - connection ID is 0");
 								return true;
 							}
 
@@ -459,7 +473,39 @@ void FGameFuseGroupsSpec::Define()
 							});
 
 							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
-																			  GameFuseGroups->RespondToGroupJoinRequest(TestConnectionData->Id, TestConnectionData->User.Id, EGFInviteRequestStatus::Declined, DeclineCallback)));
+																				  GameFuseGroups->RespondToGroupJoinRequest(TestConnectionData->Id, TestConnectionData->User.Id, EGFInviteRequestStatus::Declined, DeclineCallback)));
+
+							// Verify the group membership after declining
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+								FGFGroupCallback VerifyCallback;
+								VerifyCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+									AddInfo("DeclineRequests 6 :: Verify Group Membership After Decline");
+									
+									// Check that second user is NOT a member
+									bool bFoundMember = false;
+									for (const FGFUserData& Member : FetchedGroup.Members) {
+										if (Member.Id == UserData2->Id) {
+											bFoundMember = true;
+											break;
+										}
+									}
+									TestFalse("Second user is not a member after decline", bFoundMember);
+									
+									// Verify join requests are empty or the request is no longer pending
+									bool bHasPendingRequests = false;
+									for (const FGFGroupConnection& Request : FetchedGroup.JoinRequests) {
+										if (Request.User.Id == UserData2->Id && Request.Status == EGFInviteRequestStatus::Pending) {
+											bHasPendingRequests = true;
+											break;
+										}
+									}
+									TestFalse("No pending requests for declined user", bHasPendingRequests);
+								});
+
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																				  GameFuseGroups->FetchGroup(GroupData->Id, VerifyCallback)));
+								return true;
+							}));
 							return true;
 						}));
 						return true;
@@ -810,7 +856,7 @@ void FGameFuseGroupsSpec::Define()
 											});
 
 											ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
-																							  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+																						  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
 
 											// Fetch attributes as second user
 											ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, CreatorOnlyAttr, MemberEditableAttr]() -> bool {
@@ -959,6 +1005,822 @@ void FGameFuseGroupsSpec::Define()
 				return true;
 			}));
 			return true;
+		});
+	});
+
+	Describe("Group Join Requests and Invites", [this]() {
+		It("manages join requests for groups", [this]() {
+			// Create a test group that allows join requests
+			TSharedPtr<FGFGroup> GroupData = MakeShared<FGFGroup>();
+			GroupData->Name = TEXT("Join Requests Test Group");
+			GroupData->GroupType = TEXT("Test");
+			GroupData->MaxGroupSize = 10;
+			GroupData->bCanAutoJoin = false; // Requires approval
+			GroupData->bIsInviteOnly = false; // Allow join requests
+			GroupData->bSearchable = true;
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+				FGFGroupCallback CreateGroupCallback;
+				CreateGroupCallback.BindLambda([this, GroupData](const FGFGroup& CreatedGroup) {
+					AddInfo("JoinRequests 1 :: Create Group");
+					TestTrue("Group created successfully", CreatedGroup.Id > 0);
+					TestFalse("Group cannot auto join", CreatedGroup.bCanAutoJoin);
+					TestFalse("Group is not invite only", CreatedGroup.bIsInviteOnly);
+					GroupData->Id = CreatedGroup.Id;
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																  GameFuseGroups->CreateGroup(*GroupData, CreateGroupCallback)));
+
+				// Sign in second user to request joining
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+					FGFUserDataCallback SignInCallback;
+					SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+						AddInfo("JoinRequests 2 :: Sign In Second User");
+						TestTrue("Second user sign in succeeded", bSuccess);
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																	  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+					// Request to join the group
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+						FGFGroupConnectionCallback RequestCallback;
+						RequestCallback.BindLambda([this](const FGFGroupConnection& Connection) {
+							AddInfo("JoinRequests 3 :: Request to Join");
+							if (Connection.Id == 0) {
+								AddError("Join request failed - connection ID is 0");
+								return;
+							}
+							TestTrue("Connection has valid id", Connection.Id != 0);
+							TestEqual("Connection has correct user id", Connection.User.Id, UserData2->Id);
+							TestEqual("Connection status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+
+							// Store the connection data for later use
+							TestConnectionData = MakeShared<FGFGroupConnection>(Connection);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																		  GameFuseGroups->RequestToJoinGroup(GroupData->Id, RequestCallback)));
+
+						// Switch back to first user to check join requests
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+							FGFUserDataCallback SignInCallback;
+							SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+								AddInfo("JoinRequests 4 :: Switch Back to Creator");
+								TestTrue("Creator sign in succeeded", bSuccess);
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->SignIn(UserData1->Username + "@gamefuse.com", "password", SignInCallback)));
+
+							// Fetch the group to check join requests from server data
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+								FGFGroupCallback FetchGroupCallback;
+								FetchGroupCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+									AddInfo("JoinRequests 5 :: Fetch Group with Join Requests");
+									TestTrue("Group fetched successfully", FetchedGroup.Id == GroupData->Id);
+									TestTrue("Group has join requests", FetchedGroup.JoinRequests.Num() > 0);
+									
+									// Verify the join request details from server data
+									bool bFoundRequest = false;
+									for (const FGFGroupConnection& Request : FetchedGroup.JoinRequests) {
+										if (Request.User.Id == UserData2->Id) {
+											bFoundRequest = true;
+											TestEqual("Request status is pending", Request.Status, EGFInviteRequestStatus::Pending);
+											TestEqual("Request user ID matches", Request.User.Id, UserData2->Id);
+											TestEqual("Request username matches", Request.User.Username, UserData2->Username);
+											break;
+										}
+									}
+									TestTrue("Found the join request from second user", bFoundRequest);
+									
+									// Verify no invites exist for this non-invite-only group
+									TestEqual("Group has no invites", FetchedGroup.Invites.Num(), 0);
+								});
+
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																				  GameFuseGroups->FetchGroup(GroupData->Id, FetchGroupCallback)));
+
+								// Accept the join request
+								ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+									if (!TestConnectionData.IsValid()) {
+										AddError("Connection data is not valid");
+										return true;
+									}
+
+									FGFGroupActionCallback AcceptCallback;
+									AcceptCallback.BindLambda([this](bool bSuccess) {
+										AddInfo("JoinRequests 6 :: Accept Join Request");
+										TestTrue("Accept join request succeeded", bSuccess);
+									});
+
+									ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																					  GameFuseGroups->RespondToGroupJoinRequest(TestConnectionData->Id, TestConnectionData->User.Id, EGFInviteRequestStatus::Accepted, AcceptCallback)));
+
+									// Verify the group membership after accepting
+									ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+										FGFGroupCallback VerifyCallback;
+										VerifyCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+											AddInfo("JoinRequests 7 :: Verify Group Membership");
+											TestTrue("Group has members", FetchedGroup.Members.Num() > 0);
+											
+											// Check if second user is now a member
+											bool bFoundMember = false;
+											for (const FGFUserData& Member : FetchedGroup.Members) {
+												if (Member.Id == UserData2->Id) {
+													bFoundMember = true;
+													TestEqual("Member username matches", Member.Username, UserData2->Username);
+													break;
+												}
+											}
+											TestTrue("Second user is now a member", bFoundMember);
+											
+											// Verify join requests are empty or the request is no longer pending
+											bool bHasPendingRequests = false;
+											for (const FGFGroupConnection& Request : FetchedGroup.JoinRequests) {
+												if (Request.User.Id == UserData2->Id && Request.Status == EGFInviteRequestStatus::Pending) {
+													bHasPendingRequests = true;
+													break;
+												}
+											}
+											TestFalse("No pending requests for accepted user", bHasPendingRequests);
+										});
+
+										ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																						  GameFuseGroups->FetchGroup(GroupData->Id, VerifyCallback)));
+										return true;
+									}));
+									return true;
+								}));
+								return true;
+							}));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("manages group invites", [this]() {
+			// Create a test group that is invite-only
+			TSharedPtr<FGFGroup> GroupData = MakeShared<FGFGroup>();
+			GroupData->Name = TEXT("Group Invites Test Group");
+			GroupData->GroupType = TEXT("Test");
+			GroupData->MaxGroupSize = 10;
+			GroupData->bCanAutoJoin = false;
+			GroupData->bIsInviteOnly = true; // Make it invite-only
+			GroupData->bSearchable = true;
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+				FGFGroupCallback CreateGroupCallback;
+				CreateGroupCallback.BindLambda([this, GroupData](const FGFGroup& CreatedGroup) {
+					AddInfo("GroupInvites 1 :: Create Invite-Only Group");
+					TestTrue("Group created successfully", CreatedGroup.Id > 0);
+					TestTrue("Group is invite only", CreatedGroup.bIsInviteOnly);
+					GroupData->Id = CreatedGroup.Id;
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																  GameFuseGroups->CreateGroup(*GroupData, CreateGroupCallback)));
+
+				// Fetch the group to verify initial state (no invites, no join requests)
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+					FGFGroupCallback FetchGroupCallback;
+					FetchGroupCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+						AddInfo("GroupInvites 2 :: Verify Initial Group State");
+						TestTrue("Group fetched successfully", FetchedGroup.Id == GroupData->Id);
+						TestTrue("Group is invite only", FetchedGroup.bIsInviteOnly);
+						
+						// Initially, the group should have no invites or join requests
+						TestEqual("Group has no invites initially", FetchedGroup.Invites.Num(), 0);
+						TestEqual("Group has no join requests initially", FetchedGroup.JoinRequests.Num(), 0);
+						
+						// Verify the group only has the creator as a member
+						TestEqual("Group has only creator as member", FetchedGroup.Members.Num(), 1);
+						if (FetchedGroup.Members.Num() > 0) {
+							TestEqual("Creator is the only member", FetchedGroup.Members[0].Id, UserData1->Id);
+						}
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																	  GameFuseGroups->FetchGroup(GroupData->Id, FetchGroupCallback)));
+
+					// Create second user and invite them to the group
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+						FGFUserDataCallback SignInCallback;
+						SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+							AddInfo("GroupInvites 3 :: Sign In Second User");
+							TestTrue("Second user sign in succeeded", bSuccess);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																		  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+						// Switch back to first user (admin) to invite the second user
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+							FGFUserDataCallback SignInCallback;
+							SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+								AddInfo("GroupInvites 4 :: Switch Back to Admin");
+								TestTrue("Admin sign in succeeded", bSuccess);
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->SignIn(UserData1->Username + "@gamefuse.com", "password", SignInCallback)));
+
+							// Admin invites the second user to the group
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+								FGFGroupConnectionCallback InviteCallback;
+								InviteCallback.BindLambda([this](const FGFGroupConnection& Connection) {
+									AddInfo("GroupInvites 5 :: Admin Invites Second User");
+									if (Connection.Id == 0) {
+										AddError("Invite failed - connection ID is 0");
+										return;
+									}
+									TestTrue("Invite created successfully", Connection.Id != 0);
+									TestEqual("Invite has correct user id", Connection.User.Id, UserData2->Id);
+									TestEqual("Invite status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+
+									// Store the connection data for later use
+									TestConnectionData = MakeShared<FGFGroupConnection>(Connection);
+								});
+
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																				  GameFuseGroups->InviteGroupMember(GroupData->Id, UserData2->Id, InviteCallback)));
+
+								// Fetch the group to verify the invite was created
+								ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+									FGFGroupCallback FetchGroupCallback;
+									FetchGroupCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+										AddInfo("GroupInvites 6 :: Verify Group Has Invite");
+										TestTrue("Group fetched successfully", FetchedGroup.Id == GroupData->Id);
+										TestTrue("Group is invite only", FetchedGroup.bIsInviteOnly);
+										
+										// The group should now have an invite
+										TestTrue("Group has invites", FetchedGroup.Invites.Num() > 0);
+										
+										// Verify the invite details
+										bool bFoundInvite = false;
+										for (const FGFGroupConnection& Invite : FetchedGroup.Invites) {
+											if (Invite.User.Id == UserData2->Id) {
+												bFoundInvite = true;
+												TestEqual("Invite status is pending", Invite.Status, EGFInviteRequestStatus::Pending);
+												TestEqual("Invite user ID matches", Invite.User.Id, UserData2->Id);
+												TestEqual("Invite username matches", Invite.User.Username, UserData2->Username);
+												break;
+											}
+										}
+										TestTrue("Found the invite for second user", bFoundInvite);
+										
+										// Verify no join requests exist for this invite-only group
+										TestEqual("Group has no join requests", FetchedGroup.JoinRequests.Num(), 0);
+									});
+
+									ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																					  GameFuseGroups->FetchGroup(GroupData->Id, FetchGroupCallback)));
+
+									// Switch to second user to accept the invite
+									ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+										FGFUserDataCallback SignInCallback;
+										SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+											AddInfo("GroupInvites 7 :: Switch to Second User");
+											TestTrue("Second user sign in succeeded", bSuccess);
+										});
+
+										ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																						  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+										// Second user accepts the invite
+										ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+											if (!TestConnectionData.IsValid()) {
+												AddError("Connection data is not valid");
+												return true;
+											}
+
+											if (TestConnectionData->Id == 0) {
+												AddError("Cannot accept invite - connection ID is 0");
+												return true;
+											}
+
+											FGFGroupActionCallback AcceptCallback;
+											AcceptCallback.BindLambda([this](bool bSuccess) {
+												AddInfo("GroupInvites 8 :: Second User Accepts Invite");
+												TestTrue("Accept invite succeeded", bSuccess);
+											});
+
+											ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																							  GameFuseGroups->RespondToGroupJoinRequest(TestConnectionData->Id, TestConnectionData->User.Id, EGFInviteRequestStatus::Accepted, AcceptCallback)));
+
+											// Verify the group membership after accepting
+											ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+												FGFGroupCallback VerifyCallback;
+												VerifyCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+													AddInfo("GroupInvites 9 :: Verify Group Membership After Accept");
+													TestTrue("Group has members", FetchedGroup.Members.Num() > 0);
+													
+													// Check if second user is now a member
+													bool bFoundMember = false;
+													for (const FGFUserData& Member : FetchedGroup.Members) {
+														if (Member.Id == UserData2->Id) {
+															bFoundMember = true;
+															TestEqual("Member username matches", Member.Username, UserData2->Username);
+															break;
+														}
+													}
+													TestTrue("Second user is now a member", bFoundMember);
+													
+													// Verify invites are empty or the invite is no longer pending
+													bool bHasPendingInvites = false;
+													for (const FGFGroupConnection& Invite : FetchedGroup.Invites) {
+														if (Invite.User.Id == UserData2->Id && Invite.Status == EGFInviteRequestStatus::Pending) {
+															bHasPendingInvites = true;
+															break;
+														}
+													}
+													TestFalse("No pending invites for accepted user", bHasPendingInvites);
+												});
+
+												ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																								  GameFuseGroups->FetchGroup(GroupData->Id, VerifyCallback)));
+												return true;
+											}));
+											return true;
+										}));
+										return true;
+									}));
+									return true;
+								}));
+								return true;
+							}));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("declines join requests and invites", [this]() {
+			// Create a test group
+			TSharedPtr<FGFGroup> GroupData = MakeShared<FGFGroup>();
+			GroupData->Name = TEXT("Decline Requests Test Group");
+			GroupData->GroupType = TEXT("Test");
+			GroupData->MaxGroupSize = 10;
+			GroupData->bCanAutoJoin = false;
+			GroupData->bIsInviteOnly = false;
+			GroupData->bSearchable = true;
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+				FGFGroupCallback CreateGroupCallback;
+				CreateGroupCallback.BindLambda([this, GroupData](const FGFGroup& CreatedGroup) {
+					AddInfo("DeclineRequests 1 :: Create Group");
+					TestTrue("Group created successfully", CreatedGroup.Id > 0);
+					GroupData->Id = CreatedGroup.Id;
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																  GameFuseGroups->CreateGroup(*GroupData, CreateGroupCallback)));
+
+				// Sign in second user to request joining
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+					FGFUserDataCallback SignInCallback;
+					SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+						AddInfo("DeclineRequests 2 :: Sign In Second User");
+						TestTrue("Second user sign in succeeded", bSuccess);
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																	  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+					// Request to join the group
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+						FGFGroupConnectionCallback RequestCallback;
+						RequestCallback.BindLambda([this](const FGFGroupConnection& Connection) {
+							AddInfo("DeclineRequests 3 :: Request to Join");
+							TestTrue("Connection has valid id", Connection.Id != 0);
+							TestEqual("Connection has correct user id", Connection.User.Id, UserData2->Id);
+							TestEqual("Connection status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+
+							// Store the connection data for later use
+							TestConnectionData = MakeShared<FGFGroupConnection>(Connection);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																		  GameFuseGroups->RequestToJoinGroup(GroupData->Id, RequestCallback)));
+
+						// Switch back to first user to decline the request
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+							FGFUserDataCallback SignInCallback;
+							SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+								AddInfo("DeclineRequests 4 :: Switch Back to Creator");
+								TestTrue("Creator sign in succeeded", bSuccess);
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->SignIn(UserData1->Username + "@gamefuse.com", "password", SignInCallback)));
+
+							// Decline the join request
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+								if (!TestConnectionData.IsValid()) {
+									AddError("Connection data is not valid");
+									return true;
+								}
+
+								FGFGroupActionCallback DeclineCallback;
+								DeclineCallback.BindLambda([this](bool bSuccess) {
+									AddInfo("DeclineRequests 5 :: Decline Join Request");
+									TestTrue("Decline join request succeeded", bSuccess);
+								});
+
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																				  GameFuseGroups->RespondToGroupJoinRequest(TestConnectionData->Id, TestConnectionData->User.Id, EGFInviteRequestStatus::Declined, DeclineCallback)));
+
+								// Verify the group membership after declining
+								ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+									FGFGroupCallback VerifyCallback;
+									VerifyCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+										AddInfo("DeclineRequests 6 :: Verify Group Membership After Decline");
+										
+										// Check that second user is NOT a member
+										bool bFoundMember = false;
+										for (const FGFUserData& Member : FetchedGroup.Members) {
+											if (Member.Id == UserData2->Id) {
+												bFoundMember = true;
+												break;
+											}
+										}
+										TestFalse("Second user is not a member after decline", bFoundMember);
+										
+										// Verify join requests are empty or the request is no longer pending
+										bool bHasPendingRequests = false;
+										for (const FGFGroupConnection& Request : FetchedGroup.JoinRequests) {
+											if (Request.User.Id == UserData2->Id && Request.Status == EGFInviteRequestStatus::Pending) {
+												bHasPendingRequests = true;
+												break;
+											}
+										}
+										TestFalse("No pending requests for declined user", bHasPendingRequests);
+									});
+
+									ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																					  GameFuseGroups->FetchGroup(GroupData->Id, VerifyCallback)));
+									return true;
+								}));
+								return true;
+							}));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("handles multiple join requests and invites", [this]() {
+			// Create a test group that allows join requests (not invite-only)
+			TSharedPtr<FGFGroup> GroupData = MakeShared<FGFGroup>();
+			GroupData->Name = TEXT("Multiple Requests Test Group");
+			GroupData->GroupType = TEXT("Test");
+			GroupData->MaxGroupSize = 10;
+			GroupData->bCanAutoJoin = false;
+			GroupData->bIsInviteOnly = false; // Allow join requests
+			GroupData->bSearchable = true;
+
+			// Create a third user for testing multiple requests
+			TSharedPtr<FGFUserData> UserData3 = MakeShared<FGFUserData>();
+			UserData3->Username = "testuser3_" + FString::FromInt(FMath::RandRange(1000, 9999));
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+				FGFGroupCallback CreateGroupCallback;
+				CreateGroupCallback.BindLambda([this, GroupData](const FGFGroup& CreatedGroup) {
+					AddInfo("MultipleRequests 1 :: Create Group");
+					TestTrue("Group created successfully", CreatedGroup.Id > 0);
+					GroupData->Id = CreatedGroup.Id;
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																  GameFuseGroups->CreateGroup(*GroupData, CreateGroupCallback)));
+
+				// Create third user
+				ADD_LATENT_AUTOMATION_COMMAND(FCreateUser(TestAPIHandler, GameData, UserData3, this, FGuid()));
+
+				// Sign in second user to request joining
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+					FGFUserDataCallback SignInCallback;
+					SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+						AddInfo("MultipleRequests 2 :: Sign In Second User");
+						TestTrue("Second user sign in succeeded", bSuccess);
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																	  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+					// Request to join the group
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+						FGFGroupConnectionCallback RequestCallback;
+						RequestCallback.BindLambda([this](const FGFGroupConnection& Connection) {
+							AddInfo("MultipleRequests 3 :: Second User Request to Join");
+							if (Connection.Id == 0) {
+								AddError("Second user join request failed - connection ID is 0");
+								return;
+							}
+							TestTrue("Connection has valid id", Connection.Id != 0);
+							TestEqual("Connection has correct user id", Connection.User.Id, UserData2->Id);
+							TestEqual("Connection status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																		  GameFuseGroups->RequestToJoinGroup(GroupData->Id, RequestCallback)));
+
+						// Sign in third user to request joining
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+							FGFUserDataCallback SignInCallback;
+							SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+								AddInfo("MultipleRequests 4 :: Sign In Third User");
+								TestTrue("Third user sign in succeeded", bSuccess);
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->SignIn(UserData3->Username + "@gamefuse.com", "password", SignInCallback)));
+
+							// Request to join the group
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+								FGFGroupConnectionCallback RequestCallback;
+								RequestCallback.BindLambda([this, UserData3](const FGFGroupConnection& Connection) {
+									AddInfo("MultipleRequests 5 :: Third User Request to Join");
+									if (Connection.Id == 0) {
+										AddError("Third user join request failed - connection ID is 0");
+										return;
+									}
+									TestTrue("Connection has valid id", Connection.Id != 0);
+									TestEqual("Connection has correct user id", Connection.User.Id, UserData3->Id);
+									TestEqual("Connection status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+								});
+
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																				GameFuseGroups->RequestToJoinGroup(GroupData->Id, RequestCallback)));
+
+								// Switch back to first user to check multiple requests
+								ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+									FGFUserDataCallback SignInCallback;
+									SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+										AddInfo("MultipleRequests 6 :: Switch Back to Creator");
+										TestTrue("Creator sign in succeeded", bSuccess);
+									});
+
+									ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																					  GameFuseUser->SignIn(UserData1->Username + "@gamefuse.com", "password", SignInCallback)));
+
+									// Fetch the group to check multiple join requests
+									ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+										FGFGroupCallback FetchGroupCallback;
+										FetchGroupCallback.BindLambda([this, GroupData, UserData3](const FGFGroup& FetchedGroup) {
+											AddInfo("MultipleRequests 7 :: Fetch Group with Multiple Join Requests");
+											TestTrue("Group fetched successfully", FetchedGroup.Id == GroupData->Id);
+											TestTrue("Group has multiple join requests", FetchedGroup.JoinRequests.Num() >= 2);
+											
+											// Verify both users have pending join requests
+											bool bFoundUser2Request = false;
+											bool bFoundUser3Request = false;
+											
+											for (const FGFGroupConnection& Request : FetchedGroup.JoinRequests) {
+												if (Request.User.Id == UserData2->Id) {
+													bFoundUser2Request = true;
+													TestEqual("User2 request status is pending", Request.Status, EGFInviteRequestStatus::Pending);
+												} else if (Request.User.Id == UserData3->Id) {
+													bFoundUser3Request = true;
+													TestEqual("User3 request status is pending", Request.Status, EGFInviteRequestStatus::Pending);
+												}
+											}
+											
+											TestTrue("Found join request for user 2", bFoundUser2Request);
+											TestTrue("Found join request for user 3", bFoundUser3Request);
+											
+											// Verify no invites exist for this non-invite-only group
+											TestEqual("Group has no invites", FetchedGroup.Invites.Num(), 0);
+										});
+
+										ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																						  GameFuseGroups->FetchGroup(GroupData->Id, FetchGroupCallback)));
+										return true;
+									}));
+									return true;
+								}));
+								return true;
+							}));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("handles multiple invites for invite-only groups", [this]() {
+			// Create a test group that is invite-only
+			TSharedPtr<FGFGroup> GroupData = MakeShared<FGFGroup>();
+			GroupData->Name = TEXT("Multiple Invites Test Group");
+			GroupData->GroupType = TEXT("Test");
+			GroupData->MaxGroupSize = 10;
+			GroupData->bCanAutoJoin = false;
+			GroupData->bIsInviteOnly = true; // Make it invite-only
+			GroupData->bSearchable = true;
+
+			// Create a third user for testing multiple invites
+			TSharedPtr<FGFUserData> UserData3 = MakeShared<FGFUserData>();
+			UserData3->Username = "testuser3_" + FString::FromInt(FMath::RandRange(1000, 9999));
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+				FGFGroupCallback CreateGroupCallback;
+				CreateGroupCallback.BindLambda([this, GroupData](const FGFGroup& CreatedGroup) {
+					AddInfo("MultipleInvites 1 :: Create Invite-Only Group");
+					TestTrue("Group created successfully", CreatedGroup.Id > 0);
+					TestTrue("Group is invite only", CreatedGroup.bIsInviteOnly);
+					GroupData->Id = CreatedGroup.Id;
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																  GameFuseGroups->CreateGroup(*GroupData, CreateGroupCallback)));
+
+				// Create third user
+				ADD_LATENT_AUTOMATION_COMMAND(FCreateUser(TestAPIHandler, GameData, UserData3, this, FGuid()));
+
+				// Admin invites second user
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+					FGFGroupConnectionCallback InviteCallback1;
+					InviteCallback1.BindLambda([this](const FGFGroupConnection& Connection) {
+						AddInfo("MultipleInvites 2 :: Admin Invites Second User");
+						if (Connection.Id == 0) {
+							AddError("First invite failed - connection ID is 0");
+							return;
+						}
+						TestTrue("Invite 1 created successfully", Connection.Id != 0);
+						TestEqual("Invite 1 has correct user id", Connection.User.Id, UserData2->Id);
+						TestEqual("Invite 1 status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																	  GameFuseGroups->InviteGroupMember(GroupData->Id, UserData2->Id, InviteCallback1)));
+
+					// Admin invites third user
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+						FGFGroupConnectionCallback InviteCallback2;
+						InviteCallback2.BindLambda([this, UserData3](const FGFGroupConnection& Connection) {
+							AddInfo("MultipleInvites 3 :: Admin Invites Third User");
+							if (Connection.Id == 0) {
+								AddError("Second invite failed - connection ID is 0");
+								return;
+							}
+							TestTrue("Invite 2 created successfully", Connection.Id != 0);
+							TestEqual("Invite 2 has correct user id", Connection.User.Id, UserData3->Id);
+							TestEqual("Invite 2 status is pending", Connection.Status, EGFInviteRequestStatus::Pending);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																		  GameFuseGroups->InviteGroupMember(GroupData->Id, UserData3->Id, InviteCallback2)));
+
+						// Fetch the group to check multiple invites
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData, UserData3]() -> bool {
+							FGFGroupCallback FetchGroupCallback;
+							FetchGroupCallback.BindLambda([this, GroupData, UserData3](const FGFGroup& FetchedGroup) {
+								AddInfo("MultipleInvites 4 :: Fetch Group with Multiple Invites");
+								TestTrue("Group fetched successfully", FetchedGroup.Id == GroupData->Id);
+								TestTrue("Group has multiple invites", FetchedGroup.Invites.Num() >= 2);
+								
+								// Verify both users have pending invites
+								bool bFoundUser2Invite = false;
+								bool bFoundUser3Invite = false;
+								
+								for (const FGFGroupConnection& Invite : FetchedGroup.Invites) {
+									if (Invite.User.Id == UserData2->Id) {
+										bFoundUser2Invite = true;
+										TestEqual("User2 invite status is pending", Invite.Status, EGFInviteRequestStatus::Pending);
+									} else if (Invite.User.Id == UserData3->Id) {
+										bFoundUser3Invite = true;
+										TestEqual("User3 invite status is pending", Invite.Status, EGFInviteRequestStatus::Pending);
+									}
+								}
+								
+								TestTrue("Found invite for user 2", bFoundUser2Invite);
+								TestTrue("Found invite for user 3", bFoundUser3Invite);
+								
+								// Verify no join requests exist for this invite-only group
+								TestEqual("Group has no join requests", FetchedGroup.JoinRequests.Num(), 0);
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																			  GameFuseGroups->FetchGroup(GroupData->Id, FetchGroupCallback)));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("rejects join requests to invite-only groups", [this]() {
+			// Create a test group that is invite-only
+			TSharedPtr<FGFGroup> GroupData = MakeShared<FGFGroup>();
+			GroupData->Name = TEXT("Invite-Only Reject Test Group");
+			GroupData->GroupType = TEXT("Test");
+			GroupData->MaxGroupSize = 10;
+			GroupData->bCanAutoJoin = false;
+			GroupData->bIsInviteOnly = true; // Make it invite-only
+			GroupData->bSearchable = true;
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+				FGFGroupCallback CreateGroupCallback;
+				CreateGroupCallback.BindLambda([this, GroupData](const FGFGroup& CreatedGroup) {
+					AddInfo("RejectJoinRequest 1 :: Create Invite-Only Group");
+					TestTrue("Group created successfully", CreatedGroup.Id > 0);
+					TestTrue("Group is invite only", CreatedGroup.bIsInviteOnly);
+					GroupData->Id = CreatedGroup.Id;
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																  GameFuseGroups->CreateGroup(*GroupData, CreateGroupCallback)));
+
+				// Sign in second user to try to request joining (this should fail)
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+					FGFUserDataCallback SignInCallback;
+					SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+						AddInfo("RejectJoinRequest 2 :: Sign In Second User");
+						TestTrue("Second user sign in succeeded", bSuccess);
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																	  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+					// Try to request to join the invite-only group (this should fail)
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+						FGFGroupConnectionCallback RequestCallback;
+						RequestCallback.BindLambda([this](const FGFGroupConnection& Connection) {
+							AddInfo("RejectJoinRequest 3 :: Request to Join Invite-Only Group (Should Fail)");
+							// This should fail for invite-only groups, so we expect an empty connection
+							if (Connection.Id != 0) {
+								AddError("Join request to invite-only group should have failed but got valid connection ID");
+								return;
+							}
+							TestTrue("Connection should be invalid for invite-only group", Connection.Id == 0);
+							TestTrue("Connection should be empty for failed request", Connection.User.Id == 0);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																		  GameFuseGroups->RequestToJoinGroup(GroupData->Id, RequestCallback)));
+
+						// Switch back to first user to verify group state after failed request
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+							FGFUserDataCallback SignInCallback;
+							SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+								AddInfo("RejectJoinRequest 4 :: Switch Back to Creator");
+								TestTrue("Creator sign in succeeded", bSuccess);
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->SignIn(UserData1->Username + "@gamefuse.com", "password", SignInCallback)));
+
+							// Fetch the group to verify it still has no invites or join requests
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, GroupData]() -> bool {
+								FGFGroupCallback FetchGroupCallback;
+								FetchGroupCallback.BindLambda([this, GroupData](const FGFGroup& FetchedGroup) {
+									AddInfo("RejectJoinRequest 5 :: Verify Group State After Failed Request");
+									TestTrue("Group fetched successfully", FetchedGroup.Id == GroupData->Id);
+									TestTrue("Group is invite only", FetchedGroup.bIsInviteOnly);
+									
+									// Failed requests should not create any invites or join requests
+									TestEqual("Group has no invites after failed request", FetchedGroup.Invites.Num(), 0);
+									TestEqual("Group has no join requests after failed request", FetchedGroup.JoinRequests.Num(), 0);
+									
+									// Verify the group still only has the creator as a member
+									TestEqual("Group still has only creator as member", FetchedGroup.Members.Num(), 1);
+									if (FetchedGroup.Members.Num() > 0) {
+										TestEqual("Creator is still the only member", FetchedGroup.Members[0].Id, UserData1->Id);
+									}
+								});
+
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseGroups->GetRequestHandler(),
+																				  GameFuseGroups->FetchGroup(GroupData->Id, FetchGroupCallback)));
+								return true;
+							}));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
 		});
 	});
 }

--- a/Source/GameFuseTests/Private/Tests/GameFuseLeaderboard.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseLeaderboard.spec.cpp
@@ -288,7 +288,7 @@ void GameFuseLeaderboard::Define()
 																	  GameFuseUser->FetchMyLeaderboardEntries(10, true, VerifyFirstCallback)));
 
 					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, Score1]() -> bool {
-						const TArray<FGFLeaderboardEntry>& Entries = GameFuseUser->GetMyLeaderboardEntries();
+						const TArray<FGFLeaderboardEntry>& Entries = GameFuseUser->GetLeaderboardEntries();
 						TestEqual("Should have one entry after first add", Entries.Num(), 1);
 						if (Entries.Num() > 0) {
 							TestEqual("First score should match", Entries[0].Score, Score1);

--- a/Source/GameFuseTests/Private/Tests/GameFuseManager.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseManager.spec.cpp
@@ -48,15 +48,55 @@ void GameFuseManagerSpec::Define()
 				});
 
 				// Set up the game and capture its request ID
-
 				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseManager->GetRequestHandler(), GameFuseManager->SetUpGame(GameData->Id, GameData->Token, SetUpCallback)));
 				return true;
 			}));
 			return true;
 		}));
+	});
 
+	It("Gets server time", [this]() {
+		// Create game with callback
+		FGuid CreateGameRequestId;
+		ADD_LATENT_AUTOMATION_COMMAND(FCreateGame(TestAPIHandler, GameData, this, CreateGameRequestId));
 
-		// Wait for setup to complete
+		ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+			TestTrue("Game ID should be valid", GameData->Id != 0);
+			AddErrorIfFalse(GameData->Id != 0, TEXT("Game was not initialized"));
+			AddErrorIfFalse(GameData->Token.Len() > 0, TEXT("Game Authentication Token was not initialized"));
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				FGFApiCallback SetUpCallback;
+				SetUpCallback.AddLambda(
+				[this](const FGFAPIResponse& Response) {
+					AddInfo(TEXT("Setup Game Responded"));
+					TestTrue("setup game should be successful", Response.bSuccess);
+					TestTrue("GameFuseManager should be set up", GameFuseManager->IsSetUp());
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseManager->GetRequestHandler(), GameFuseManager->SetUpGame(GameData->Id, GameData->Token, SetUpCallback)));
+
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+					FGFApiCallback GetServerTimeCallback;
+					GetServerTimeCallback.AddLambda(
+					[this](const FGFAPIResponse& Response) {
+						AddInfo(TEXT("GetServerTime Responded"));
+						TestTrue("GetServerTime should be successful", Response.bSuccess);
+						
+						if (Response.bSuccess) {
+							const FGFGameData& GameData = GameFuseManager->GetGameData();
+							TestFalse("Server time should not be empty", GameData.ServerTime.IsEmpty());
+							AddInfo(FString::Printf(TEXT("Server time received: %s"), *GameData.ServerTime));
+						}
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseManager->GetRequestHandler(), GameFuseManager->GetServerTime(GetServerTimeCallback)));
+					return true;
+				}));
+				return true;
+			}));
+			return true;
+		}));
 	});
 }
 

--- a/Source/GameFuseTests/Private/Tests/GameFuseManager.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseManager.spec.cpp
@@ -90,7 +90,7 @@ void GameFuseManagerSpec::Define()
 						}
 					});
 
-					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseManager->GetRequestHandler(), GameFuseManager->GetServerTime(GetServerTimeCallback)));
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseManager->GetRequestHandler(), GameFuseManager->FetchServerTime(GetServerTimeCallback)));
 					return true;
 				}));
 				return true;

--- a/Source/GameFuseTests/Private/Tests/GameFuseRounds.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseRounds.spec.cpp
@@ -316,7 +316,7 @@ void GameFuseRoundsSpec::Define()
 			}));
 		});
 
-		xIt("fetches a specific game round", [this]() {
+		It("fetches a specific game round", [this]() {
 			// todo:: fix fetching a specific game round
 
 			TSharedPtr<FGFGameRound> RoundData = MakeShared<FGFGameRound>();
@@ -434,7 +434,121 @@ void GameFuseRoundsSpec::Define()
 						});
 
 						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseRounds->GetRequestHandler(),
-																		  GameFuseRounds->FetchUserGameRounds(FetchCallback)));
+																		  GameFuseRounds->FetchMyGameRounds(FetchCallback)));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("gets another users game rounds", [this]()
+		{
+			TSharedPtr<FGFUserData> OtherUser = MakeShared<FGFUserData>();
+			ADD_LATENT_AUTOMATION_COMMAND(FCreateUser(TestAPIHandler, GameData, OtherUser, this, FGuid()));
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, OtherUser]() -> bool
+			{
+				// Create 2 rounds for the other user
+				TSharedPtr<FGFGameRound> Round1 = MakeShared<FGFGameRound>();
+				Round1->Score = 100;
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseRounds->GetRequestHandler(),
+																  GameFuseRounds->CreateGameRound(
+																	  *Round1, *OtherUser, FGFGameRoundCallback())));
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, OtherUser]() -> bool
+				{
+					TSharedPtr<FGFGameRound> Round2 = MakeShared<FGFGameRound>();
+					Round2->Score = 200;
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseRounds->GetRequestHandler(),
+																	  GameFuseRounds->CreateGameRound(
+																		  *Round2, *OtherUser, FGFGameRoundCallback())));
+
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, OtherUser]() -> bool
+					{
+						// Fetch the other user's rounds
+						FGFGameRoundListCallback FetchCallback;
+						FetchCallback.BindLambda([this, OtherUser](const TArray<FGFGameRound>& Rounds)
+						{
+							AddInfo("GetUserRounds :: Verify another user's rounds");
+							TestEqual("Should have exactly 2 rounds", Rounds.Num(), 2);
+
+							if (Rounds.Num() == 2)
+							{
+								TestEqual("Round owner is correct", Rounds[0].GameUserId, OtherUser->Id);
+							}
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseRounds->GetRequestHandler(),
+																		  GameFuseRounds->FetchUserGameRounds(OtherUser->Id, FetchCallback)));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+		
+		It("gets another users game rounds with pagination", [this]()
+		{
+			TSharedPtr<FGFUserData> OtherUser = MakeShared<FGFUserData>();
+			ADD_LATENT_AUTOMATION_COMMAND(FCreateUser(TestAPIHandler, GameData, OtherUser, this, FGuid()));
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, OtherUser]() -> bool
+			{
+				// Create 2 rounds for the other user
+				TSharedPtr<FGFGameRound> Round1 = MakeShared<FGFGameRound>();
+				Round1->Score = 100;
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseRounds->GetRequestHandler(),
+																  GameFuseRounds->CreateGameRound(*Round1, *OtherUser, FGFGameRoundCallback())));
+
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, OtherUser]() -> bool
+				{
+					TSharedPtr<FGFGameRound> Round2 = MakeShared<FGFGameRound>();
+					Round2->Score = 200;
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseRounds->GetRequestHandler(),
+																	  GameFuseRounds->CreateGameRound(*Round2, *OtherUser, FGFGameRoundCallback())));
+
+					// Test pagination: page 1, per_page 1
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, OtherUser]() -> bool
+					{
+						FGFGameRoundListCallback FetchCallback1;
+						FetchCallback1.BindLambda([this](const TArray<FGFGameRound>& Rounds)
+						{
+							AddInfo("GetUserRounds Pagination :: Page 1");
+							TestEqual("Should have exactly 1 round on page 1", Rounds.Num(), 1);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseRounds->GetRequestHandler(),
+																		  GameFuseRounds->FetchUserGameRounds(OtherUser->Id, FetchCallback1, "", 1, 1)));
+						
+						// Test pagination: page 2, per_page 1
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, OtherUser]() -> bool
+						{
+							FGFGameRoundListCallback FetchCallback2;
+							FetchCallback2.BindLambda([this](const TArray<FGFGameRound>& Rounds)
+							{
+								AddInfo("GetUserRounds Pagination :: Page 2");
+								TestEqual("Should have exactly 1 round on page 2", Rounds.Num(), 1);
+							});
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseRounds->GetRequestHandler(),
+																			  GameFuseRounds->FetchUserGameRounds(OtherUser->Id, FetchCallback2, "", 2, 1)));
+
+							// Test pagination: page 3, should be empty
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, OtherUser]() -> bool
+							{
+								FGFGameRoundListCallback FetchCallback3;
+								FetchCallback3.BindLambda([this](const TArray<FGFGameRound>& Rounds)
+								{
+									AddInfo("GetUserRounds Pagination :: Page 3");
+									TestTrue("Page 3 should be empty", Rounds.IsEmpty());
+								});
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseRounds->GetRequestHandler(),
+																				  GameFuseRounds->FetchUserGameRounds(OtherUser->Id, FetchCallback3, "", 3, 1)));
+								return true;
+							}));
+							return true;
+						}));
 						return true;
 					}));
 					return true;

--- a/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
@@ -913,6 +913,84 @@ void GameFuseUserSpec::Define()
 				return true;
 			}));
 		});
+
+		It("fetches other user's data", [this]() {
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				// First user adds score
+				FGFUserDataCallback AddScoreCallback;
+				AddScoreCallback.BindLambda([this](bool bSuccess, const FGFUserData& User) {
+					AddInfo("FetchUserData 1 :: Add Score for First User");
+					TestTrue("Add score request succeeded for first user", bSuccess);
+					if (!bSuccess) {
+						AddError(TEXT("Failed to add score for first user"));
+						return;
+					}
+					TestEqual("Score was added correctly for first user", User.Score, 1000);
+					TestEqual("User ID matches first user", User.Id, UserData->Id);
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																  GameFuseUser->AddScore(1000, AddScoreCallback)));
+
+				// Verify score was added before signing in as second user
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+					FGFUserDataCallback VerifyCallback;
+					VerifyCallback.BindLambda([this](bool bSuccess, const FGFUserData& User) {
+						AddInfo("FetchUserData 2 :: Verify Score for First User");
+						TestTrue("Verify score request succeeded for first user", bSuccess);
+						if (bSuccess) {
+							TestEqual("Score should be 1000 for first user", User.Score, 1000);
+						}
+					});
+					// Temporarily fetch current user to check score.
+					// Note: This will be UserData (first user) as they are still signed in.
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																	  GameFuseUser->FetchUser(UserData->Id, VerifyCallback)));
+
+
+					// Sign in as second user
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+						FGFUserDataCallback SignInCallback;
+						SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& SignedInUser) {
+							AddInfo("FetchUserData 3 :: Sign In Second User");
+							TestTrue("Second user sign in succeeded", bSuccess);
+							if (!bSuccess) {
+								AddError(TEXT("Second user sign in failed"));
+								return;
+							}
+							TestEqual("Signed in user ID matches second user", SignedInUser.Id, UserData2->Id);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																		  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+						// Fetch first user's data
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+							FGFUserDataCallback FetchCallback;
+							FetchCallback.BindLambda([this](bool bSuccess, const FGFUserData& FetchedUser) {
+								AddInfo("FetchUserData 4 :: Fetch First User Data");
+								if (!bSuccess) {
+									AddError("Fetch user data request failed");
+									return;
+								}
+								TestTrue("Fetch user data request succeeded", bSuccess);
+								TestEqual("Fetched User ID matches first user", FetchedUser.Id, UserData->Id);
+								TestEqual("Fetched Username matches first user", FetchedUser.Username, UserData->Username);
+								TestEqual("Fetched Score matches first user's score", FetchedUser.Score, 1000);
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->FetchUser(UserData->Id, FetchCallback)));
+							ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
 	});
 }
 

--- a/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
@@ -85,7 +85,7 @@ void GameFuseUserSpec::Define()
 					TestTrue("User data is valid", UserData.Id > 0);
 					TestEqual("Username matches", UserData.Username, UserData.Username);
 					TestTrue("User is signed in", GameFuseUser->IsSignedIn());
-					TestEqual("Internal last fetched user data matches", GameFuseUser->GetLastFetchedUserData().Id, UserData.Id);
+					TestEqual("Internal last fetched user data matches", GameFuseUser->GetCurrentUserData().Id, UserData.Id);
 					TestEqual("Internal current user data matches", GameFuseUser->GetCurrentUserData().Id, UserData.Id);
 					TestEqual("Internal username matches", GameFuseUser->GetUsername(), UserData.Username);
 					TestTrue("Authentication token is valid", !GameFuseUser->GetAuthenticationToken().IsEmpty());

--- a/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
@@ -254,7 +254,7 @@ void GameFuseUserSpec::Define()
 						});
 
 						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
-																		  GameFuseUser->FetchPurchasedStoreItems(FetchCallback)));
+																		  GameFuseUser->FetchMyPurchasedStoreItems(FetchCallback)));
 						ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
 						return true;
 					}));
@@ -381,7 +381,7 @@ void GameFuseUserSpec::Define()
 						});
 
 						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
-																		  GameFuseUser->FetchAttributes(FetchCallback)));
+																		  GameFuseUser->FetchMyAttributes(FetchCallback)));
 						ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
 						return true;
 					}));
@@ -452,7 +452,7 @@ void GameFuseUserSpec::Define()
 					});
 
 					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
-																	  GameFuseUser->FetchAttributes(FetchCallback)));
+																	  GameFuseUser->FetchMyAttributes(FetchCallback)));
 					ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
 					return true;
 				}));
@@ -512,7 +512,7 @@ void GameFuseUserSpec::Define()
 						});
 
 						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
-																		  GameFuseUser->FetchAttributes(FetchCallback)));
+																		  GameFuseUser->FetchMyAttributes(FetchCallback)));
 						ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
 						return true;
 					}));
@@ -569,7 +569,7 @@ void GameFuseUserSpec::Define()
 					});
 
 					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
-																	  GameFuseUser->FetchAttributes(FetchCallback)));
+																	  GameFuseUser->FetchMyAttributes(FetchCallback)));
 					ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
 					return true;
 				}));

--- a/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
@@ -13,6 +13,7 @@ UGameInstance* GameInstance;
 UTestAPIHandler* TestAPIHandler;
 TSharedPtr<FGFGameData> GameData;
 TSharedPtr<FGFUserData> UserData;
+TSharedPtr<FGFUserData> UserData2;
 bool bCleanupSuccess;
 END_DEFINE_SPEC(GameFuseUserSpec);
 
@@ -31,6 +32,7 @@ void GameFuseUserSpec::Define()
 	// init testing data
 	GameData = MakeShared<FGFGameData>();
 	UserData = MakeShared<FGFUserData>();
+	UserData2 = MakeShared<FGFUserData>();
 	bCleanupSuccess = false;
 
 	Describe("GameFuseUser Authentication", [this]() {
@@ -571,6 +573,341 @@ void GameFuseUserSpec::Define()
 					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
 																	  GameFuseUser->FetchMyAttributes(FetchCallback)));
 					ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
+					return true;
+				}));
+				return true;
+			}));
+		});
+	});
+
+	Describe("GameFuseUser Multi-User Features", [this]() {
+		BeforeEach([this]() {
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				if (GameFuseManager->IsSetUp()) {
+					UE_LOG(LogGameFuse, Warning, TEXT("Game was already Setup"));
+					GameFuseManager->ClearGameData();
+					return false; // Keep waiting
+				}
+				UE_LOG(LogGameFuse, Log, TEXT("GameFuseManager cleanup complete"));
+				return true;
+			}));
+
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				if (GameFuseUser->IsSignedIn()) {
+					UE_LOG(LogGameFuse, Warning, TEXT("User was already Signed in"));
+					GameFuseUser->LogOut();
+					return false; // Keep waiting
+				}
+				UE_LOG(LogGameFuse, Log, TEXT("GameFuseUser cleanup complete"));
+				return true;
+			}));
+
+			// Create and setup game
+			ADD_LATENT_AUTOMATION_COMMAND(FSetupGame(TestAPIHandler, GameData, GameFuseManager, this, FGuid()));
+
+			// Wait for GameFuseManager to be fully set up
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				if (!GameFuseManager->IsSetUp()) {
+					UE_LOG(LogGameFuse, Warning, TEXT("Waiting for GameFuseManager setup..."));
+					return false; // Keep waiting
+				}
+				UE_LOG(LogGameFuse, Log, TEXT("GameFuseManager setup complete"));
+				return true;
+			}));
+
+			// Create and sign in first user
+			ADD_LATENT_AUTOMATION_COMMAND(FSetupUser(TestAPIHandler, GameData, UserData, GameFuseUser, this));
+
+			// Wait for user to be fully signed in
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				if (!GameFuseUser->IsSignedIn()) {
+					UE_LOG(LogGameFuse, Warning, TEXT("Waiting for user signin..."));
+					return false; // Keep waiting
+				}
+				UE_LOG(LogGameFuse, Log, TEXT("User signed in successfully"));
+				return true;
+			}));
+
+			// Create second user
+			ADD_LATENT_AUTOMATION_COMMAND(FCreateUser(TestAPIHandler, GameData, UserData2, this, FGuid()));
+		});
+
+		It("fetches other users attributes", [this]() {
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				// Set attributes on primary user
+				TMap<FString, FString> TestAttributes;
+				TestAttributes.Add("test_key1", "test_value1");
+				TestAttributes.Add("test_key2", "test_value2");
+
+				FGFAttributesCallback SetAttributesCallback;
+				SetAttributesCallback.BindLambda([this](bool bSuccess, const FGFAttributeList& Attributes) {
+					AddInfo("FetchUserAttributes 1 :: Set Attributes");
+					if (!bSuccess) {
+						AddError("Set attributes request failed");
+						return;
+					}
+					TestTrue("Set attributes request succeeded", bSuccess);
+					TestTrue("Attributes should be valid", Attributes.Attributes.Num() > 0);
+					if (Attributes.Attributes.Num() > 0) {
+						TestEqual("Should have two attributes", Attributes.Attributes.Num(), 2);
+						const FString* Value1 = Attributes.Attributes.Find("test_key1");
+						const FString* Value2 = Attributes.Attributes.Find("test_key2");
+						TestNotNull("First attribute should exist", Value1);
+						TestNotNull("Second attribute should exist", Value2);
+						if (Value1 && Value2) {
+							TestEqual("First attribute value should match", *Value1, "test_value1");
+							TestEqual("Second attribute value should match", *Value2, "test_value2");
+						}
+					}
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																  GameFuseUser->SetAttributes(TestAttributes, SetAttributesCallback)));
+
+				// Verify attributes were set before signing in as second user
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+					FGFAttributesCallback VerifyCallback;
+					VerifyCallback.BindLambda([this](bool bSuccess, const FGFAttributeList& Attributes) {
+						AddInfo("FetchUserAttributes 2 :: Verify Attributes");
+						TestTrue("Verify attributes request succeeded", bSuccess);
+						if (bSuccess) {
+							TestEqual("Should have two attributes", Attributes.Attributes.Num(), 2);
+						}
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																	  GameFuseUser->FetchMyAttributes(VerifyCallback)));
+
+					// Sign in as second user and fetch attributes from first user
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+						FGFUserDataCallback SignInCallback;
+						SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+							AddInfo("FetchUserAttributes 3 :: Sign In Second User");
+							TestTrue("Second user sign in succeeded", bSuccess);
+							if (!bSuccess) {
+								AddError(TEXT("Second user sign in failed"));
+								return;
+							}
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																		  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+						// Fetch first users attributes
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+							FGFAttributesCallback FetchCallback;
+							FetchCallback.BindLambda([this](bool bSuccess, const FGFAttributeList& Attributes) {
+								AddInfo("FetchUserAttributes 4 :: Fetch First User Attributes");
+								if (!bSuccess) {
+									AddError("Fetch user attributes request failed");
+									return;
+								}
+								TestTrue("Fetch user attributes request succeeded", bSuccess);
+								TestTrue("Attributes should be valid", Attributes.Attributes.Num() > 0);
+								if (Attributes.Attributes.Num() > 0) {
+									TestEqual("Should have two attributes", Attributes.Attributes.Num(), 2);
+									const FString* Value1 = Attributes.Attributes.Find("test_key1");
+									const FString* Value2 = Attributes.Attributes.Find("test_key2");
+									TestNotNull("First attribute should exist", Value1);
+									TestNotNull("Second attribute should exist", Value2);
+									if (Value1 && Value2) {
+										TestEqual("First attribute value should match", *Value1, "test_value1");
+										TestEqual("Second attribute value should match", *Value2, "test_value2");
+									}
+								}
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->FetchUserAttributes(UserData->Id, FetchCallback)));
+							ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("fetches other users leaderboard entries", [this]() {
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				// Add leaderboard entry for first user
+				FGFInternalSuccessCallback AddEntryCallback;
+				AddEntryCallback.AddLambda([this](bool bSuccess) {
+					AddInfo("FetchUserLeaderboard 1 :: Add Leaderboard Entry");
+					TestTrue("Add leaderboard entry request succeeded", bSuccess);
+					if (!bSuccess) {
+						AddError(TEXT("Failed to add leaderboard entry"));
+						return;
+					}
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																  GameFuseUser->AddLeaderboardEntry("test_leaderboard", 1000, AddEntryCallback)));
+
+				// Verify leaderboard entry was added before signing in as second user
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+					FGFLeaderboardEntriesCallback VerifyCallback;
+					VerifyCallback.BindLambda([this](bool bSuccess, const TArray<FGFLeaderboardEntry>& Entries) {
+						AddInfo("FetchUserLeaderboard 2 :: Verify Leaderboard Entry");
+						TestTrue("Verify leaderboard entries request succeeded", bSuccess);
+						if (bSuccess) {
+							TestEqual("Should have one leaderboard entry", Entries.Num(), 1);
+						}
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																	  GameFuseUser->FetchMyLeaderboardEntries(100, true, VerifyCallback)));
+
+					// Sign in as second user
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+						FGFUserDataCallback SignInCallback;
+						SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+							AddInfo("FetchUserLeaderboard 3 :: Sign In Second User");
+							TestTrue("Second user sign in succeeded", bSuccess);
+							if (!bSuccess) {
+								AddError(TEXT("Second user sign in failed"));
+								return;
+							}
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																		  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+						// Fetch first users leaderboard entries
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+							FGFLeaderboardEntriesCallback FetchCallback;
+							FetchCallback.BindLambda([this](bool bSuccess, const TArray<FGFLeaderboardEntry>& Entries) {
+								AddInfo("FetchUserLeaderboard 4 :: Fetch First User Leaderboard Entries");
+								if (!bSuccess) {
+									AddError("Fetch user leaderboard entries request failed");
+									return;
+								}
+								TestTrue("Fetch user leaderboard entries request succeeded", bSuccess);
+								TestEqual("Should have one leaderboard entry", Entries.Num(), 1);
+								if (Entries.Num() > 0) {
+									const FGFLeaderboardEntry& Entry = Entries[0];
+									TestEqual("Leaderboard name matches", Entry.LeaderboardName, "test_leaderboard");
+									TestEqual("Score matches", Entry.Score, 1000);
+									TestEqual("User ID matches first user", Entry.GameUserId, UserData->Id);
+								}
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->FetchUserLeaderboardEntries(UserData->Id, 100, true, FetchCallback)));
+							ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("fetches other users store items", [this]() {
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				// Create store item
+				TSharedPtr<FGFStoreItem> TestStoreItem = MakeShared<FGFStoreItem>();
+				TestStoreItem->Name = TEXT("Test Item");
+				TestStoreItem->Description = TEXT("A test store item");
+				TestStoreItem->Cost = 100;
+				TestStoreItem->Category = TEXT("test");
+
+				ADD_LATENT_AUTOMATION_COMMAND(FCreateStoreItem(TestAPIHandler, GameData, TestStoreItem, this, FGuid()));
+
+				// Add credits and purchase item for first user
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, TestStoreItem]() -> bool {
+					FGFUserDataCallback AddCreditsCallback;
+					AddCreditsCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+						AddInfo("FetchUserStoreItems 1 :: Add Credits");
+						TestTrue("Add credits request succeeded", bSuccess);
+						if (!bSuccess) {
+							AddError(TEXT("Failed to add credits"));
+							return;
+						}
+						TestEqual("Credits were added", UserData.Credits, 200);
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																	  GameFuseUser->AddCredits(200, AddCreditsCallback)));
+
+					// Purchase store item
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this, TestStoreItem]() -> bool {
+						FGFStoreItemsCallback PurchaseCallback;
+						PurchaseCallback.BindLambda([this](bool bSuccess, const TArray<FGFStoreItem>& StoreItems) {
+							AddInfo("FetchUserStoreItems 2 :: Purchase Store Item");
+							TestTrue("Purchase store item request succeeded", bSuccess);
+							if (!bSuccess) {
+								AddError(TEXT("Failed to purchase store item"));
+								return;
+							}
+							TestEqual("Should have one purchased item", StoreItems.Num(), 1);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																		  GameFuseUser->PurchaseStoreItem(TestStoreItem->Id, PurchaseCallback)));
+
+						// Verify purchase before signing in as second user
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+							FGFStoreItemsCallback VerifyCallback;
+							VerifyCallback.BindLambda([this](bool bSuccess, const TArray<FGFStoreItem>& StoreItems) {
+								AddInfo("FetchUserStoreItems 3 :: Verify Purchase");
+								TestTrue("Verify purchased items request succeeded", bSuccess);
+								if (bSuccess) {
+									TestEqual("Should have one purchased item", StoreItems.Num(), 1);
+								}
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->FetchMyPurchasedStoreItems(VerifyCallback)));
+
+							// Sign in as second user
+							ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+								FGFUserDataCallback SignInCallback;
+								SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& UserData) {
+									AddInfo("FetchUserStoreItems 4 :: Sign In Second User");
+									TestTrue("Second user sign in succeeded", bSuccess);
+									if (!bSuccess) {
+										AddError(TEXT("Second user sign in failed"));
+										return;
+									}
+								});
+
+								ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																				  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+								// Fetch first users store items
+								ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+									FGFStoreItemsCallback FetchCallback;
+									FetchCallback.BindLambda([this](bool bSuccess, const TArray<FGFStoreItem>& StoreItems) {
+										AddInfo("FetchUserStoreItems 5 :: Fetch First User Store Items");
+										if (!bSuccess) {
+											AddError("Fetch user store items request failed");
+											return;
+										}
+										TestTrue("Fetch user store items request succeeded", bSuccess);
+										TestEqual("Should have one purchased item", StoreItems.Num(), 1);
+										if (StoreItems.Num() > 0) {
+											const FGFStoreItem& Item = StoreItems[0];
+											TestEqual("Store item cost matches", Item.Cost, 100);
+											TestEqual("Store item name matches", Item.Name, TEXT("Test Item"));
+										}
+									});
+
+									ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																					  GameFuseUser->FetchUserPurchasedStoreItems(UserData->Id, FetchCallback)));
+									ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
+									return true;
+								}));
+								return true;
+							}));
+							return true;
+						}));
+						return true;
+					}));
 					return true;
 				}));
 				return true;

--- a/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
@@ -524,6 +524,74 @@ void GameFuseUserSpec::Define()
 			}));
 		});
 
+		It("removes attributes in bulk", [this]() {
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				// First set some attributes
+				TMap<FString, FString> TestAttributes;
+				TestAttributes.Add("test_key1", "test_value1");
+				TestAttributes.Add("test_key2", "test_value2");
+				TestAttributes.Add("test_key3", "test_value3");
+
+				FGFAttributesCallback SetAttributesCallback;
+				SetAttributesCallback.BindLambda([this](bool bSuccess, const FGFAttributeList& Attributes) {
+					AddInfo("RemoveAttributesBulk 1 :: Set Initial Attributes");
+					if (!bSuccess) {
+						TestFalse("Set attributes request failed", true);
+						return;
+					}
+					TestEqual("Should have three attributes", Attributes.Attributes.Num(), 3);
+					TestEqual("First attribute should match", Attributes.Attributes["test_key1"], "test_value1");
+					TestEqual("Second attribute should match", Attributes.Attributes["test_key2"], "test_value2");
+					TestEqual("Third attribute should match", Attributes.Attributes["test_key3"], "test_value3");
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+															  GameFuseUser->SetAttributes(TestAttributes, SetAttributesCallback)));
+
+				// Remove two attributes
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+					TArray<FString> KeysToRemove;
+					KeysToRemove.Add("test_key1");
+					KeysToRemove.Add("test_key3");
+
+					FGFAttributesCallback RemoveCallback;
+					RemoveCallback.BindLambda([this](bool bSuccess, const FGFAttributeList& Attributes) {
+						AddInfo("RemoveAttributesBulk 2 :: Remove Attributes");
+						if (!bSuccess) {
+							AddErrorIfFalse(bSuccess, "Remove attributes request failed");
+							return;
+						}
+						TestEqual("Should have one attribute remaining", Attributes.Attributes.Num(), 1);
+						TestEqual("Remaining attribute should match", Attributes.Attributes["test_key2"], "test_value2");
+					});
+
+					ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+															  GameFuseUser->RemoveAttributes(KeysToRemove, RemoveCallback)));
+
+					// Verify remaining attributes
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+						FGFAttributesCallback FetchCallback;
+						FetchCallback.BindLambda([this](bool bSuccess, const FGFAttributeList& Attributes) {
+							AddInfo("RemoveAttributesBulk 3 :: Verify Attributes");
+							if (!bSuccess) {
+								AddErrorIfFalse(bSuccess, "Fetch attributes request failed");
+								return;
+							}
+							TestEqual("Should have one attribute", Attributes.Attributes.Num(), 1);
+							TestEqual("Remaining attribute should match", Attributes.Attributes["test_key2"], "test_value2");
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+															  GameFuseUser->FetchMyAttributes(FetchCallback)));
+						ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
 		It("syncs local attributes", [this]() {
 			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
 				// First set some local attributes
@@ -914,7 +982,7 @@ void GameFuseUserSpec::Define()
 			}));
 		});
 
-		It("fetches other user's data", [this]() {
+		It("fetches other users data", [this]() {
 			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
 				// First user adds score
 				FGFUserDataCallback AddScoreCallback;

--- a/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
+++ b/Source/GameFuseTests/Private/Tests/GameFuseUser.spec.cpp
@@ -85,7 +85,8 @@ void GameFuseUserSpec::Define()
 					TestTrue("User data is valid", UserData.Id > 0);
 					TestEqual("Username matches", UserData.Username, UserData.Username);
 					TestTrue("User is signed in", GameFuseUser->IsSignedIn());
-					TestEqual("Internal user data matches", GameFuseUser->GetUserData().Id, UserData.Id);
+					TestEqual("Internal last fetched user data matches", GameFuseUser->GetLastFetchedUserData().Id, UserData.Id);
+					TestEqual("Internal current user data matches", GameFuseUser->GetCurrentUserData().Id, UserData.Id);
 					TestEqual("Internal username matches", GameFuseUser->GetUsername(), UserData.Username);
 					TestTrue("Authentication token is valid", !GameFuseUser->GetAuthenticationToken().IsEmpty());
 				});
@@ -1045,6 +1046,92 @@ void GameFuseUserSpec::Define()
 								TestEqual("Fetched User ID matches first user", FetchedUser.Id, UserData->Id);
 								TestEqual("Fetched Username matches first user", FetchedUser.Username, UserData->Username);
 								TestEqual("Fetched Score matches first user's score", FetchedUser.Score, 1000);
+								
+								// Verify that the last fetched user data contains the first user's data
+								// while current user data still contains the second user's data
+								TestEqual("Last fetched user data should contain first user", GameFuseUser->GetLastFetchedUserData().Id, UserData->Id);
+								TestEqual("Current user data should still contain second user", GameFuseUser->GetCurrentUserData().Id, UserData2->Id);
+							});
+
+							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																			  GameFuseUser->FetchUser(UserData->Id, FetchCallback)));
+							ADD_LATENT_AUTOMATION_COMMAND(FCleanupGame(TestAPIHandler, GameData, bCleanupSuccess, this, FGuid()));
+							return true;
+						}));
+						return true;
+					}));
+					return true;
+				}));
+				return true;
+			}));
+		});
+
+		It("maintains current user data when fetching other users", [this]() {
+			ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+				// First user adds some data
+				FGFUserDataCallback AddScoreCallback;
+				AddScoreCallback.BindLambda([this](bool bSuccess, const FGFUserData& User) {
+					AddInfo("CurrentUserDataTest 1 :: Add Score for First User");
+					TestTrue("Add score request succeeded for first user", bSuccess);
+					if (!bSuccess) {
+						AddError(TEXT("Failed to add score for first user"));
+						return;
+					}
+					TestEqual("Score was added correctly for first user", User.Score, 500);
+					TestEqual("User ID matches first user", User.Id, UserData->Id);
+				});
+
+				ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																  GameFuseUser->AddScore(500, AddScoreCallback)));
+
+				// Verify current user data contains first user's data
+				ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+					TestEqual("Current user data should contain first user ID", GameFuseUser->GetCurrentUserData().Id, UserData->Id);
+					TestEqual("Current user data should contain first user score", GameFuseUser->GetCurrentUserData().Score, 500);
+					TestEqual("Last fetched user data should also contain first user ID", GameFuseUser->GetLastFetchedUserData().Id, UserData->Id);
+					TestEqual("Last fetched user data should also contain first user score", GameFuseUser->GetLastFetchedUserData().Score, 500);
+
+					// Sign in as second user
+					ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+						FGFUserDataCallback SignInCallback;
+						SignInCallback.BindLambda([this](bool bSuccess, const FGFUserData& SignedInUser) {
+							AddInfo("CurrentUserDataTest 2 :: Sign In Second User");
+							TestTrue("Second user sign in succeeded", bSuccess);
+							if (!bSuccess) {
+								AddError(TEXT("Second user sign in failed"));
+								return;
+							}
+							TestEqual("Signed in user ID matches second user", SignedInUser.Id, UserData2->Id);
+							
+							// Verify current user data now contains second user's data
+							TestEqual("Current user data should now contain second user ID", GameFuseUser->GetCurrentUserData().Id, UserData2->Id);
+							TestEqual("Last fetched user data should also contain second user ID", GameFuseUser->GetLastFetchedUserData().Id, UserData2->Id);
+						});
+
+						ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),
+																		  GameFuseUser->SignIn(UserData2->Username + "@gamefuse.com", "password", SignInCallback)));
+
+						// Fetch first user's data
+						ADD_LATENT_AUTOMATION_COMMAND(FFunctionLatentCommand([this]() -> bool {
+							FGFUserDataCallback FetchCallback;
+							FetchCallback.BindLambda([this](bool bSuccess, const FGFUserData& FetchedUser) {
+								AddInfo("CurrentUserDataTest 3 :: Fetch First User Data");
+								if (!bSuccess) {
+									AddError("Fetch user data request failed");
+									return;
+								}
+								TestTrue("Fetch user data request succeeded", bSuccess);
+								TestEqual("Fetched User ID matches first user", FetchedUser.Id, UserData->Id);
+								TestEqual("Fetched Score matches first user's score", FetchedUser.Score, 500);
+								
+								// Verify that the last fetched user data now contains the first user's data
+								// while current user data still contains the second user's data
+								TestEqual("Last fetched user data should contain first user", GameFuseUser->GetLastFetchedUserData().Id, UserData->Id);
+								TestEqual("Last fetched user data should contain first user score", GameFuseUser->GetLastFetchedUserData().Score, 500);
+								TestEqual("Current user data should still contain second user", GameFuseUser->GetCurrentUserData().Id, UserData2->Id);
+								
+								// Verify that current user data is not affected by the fetch operation
+								TestNotEqual("Current user data should not be affected by fetch", GameFuseUser->GetCurrentUserData().Id, UserData->Id);
 							});
 
 							ADD_LATENT_AUTOMATION_COMMAND(FWaitForFGFResponse(GameFuseUser->GetRequestHandler(),

--- a/Source/GameFuseTests/Public/GameFuseTests.h
+++ b/Source/GameFuseTests/Public/GameFuseTests.h
@@ -11,11 +11,5 @@ public:
 
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
-	UGameInstance* GameInstance;
-	UGameFuseManager* GameFuseManager;
-	TSharedPtr<FGFGameData> GameData;
-	TObjectPtr<UTestAPIHandler> TestAPIHandler;
 
-
-	bool isSetUp = false;
 };


### PR DESCRIPTION
- **separate fetch fns for User/My: attributes, leaderboard entries, storeitems**
- **tests for fetching extra data from a second user**
- **update to can_others_edit when creating attributes**
- **5.3 build fixes**
- **add fetch user API call**
- **fix attribute removal actions**
- **add get server time, fix tests for game fuse groups auto join/invite only**
- **get friends for other users**
- **public game round getters**
- **refactor user data into current user and last fetched user, add comments**
- **add comments, rename AllGroups to FetchedGroups for consistency**
- **refactor structs and APIs to use `CurrentUserData`, add invite group member functionality, and enhance test coverage**
- **fixed invite to group test**
- **rename AllChats to CachedChats, add docs  comments to structs**
